### PR TITLE
fix(cli): pin `wheel` version to fix broken installation for MacOS.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tree-sitter-language-pack",
     "pygments",
     "transformers>=4.36.0",
+    "wheel<0.46.0",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/pypa/wheel/blob/0.45.1/src/wheel/macosx_libfile.py this file is removed in `wheel==0.46.0`, which caused issue when building chroma-hnswlib.