### PR TITLE
Allow vectorising hidden files

### DIFF
--- a/src/vectorcode/subcommands/vectorise.py
+++ b/src/vectorcode/subcommands/vectorise.py
@@ -122,8 +122,7 @@ def load_files_from_include(project_root: str) -> list[str]:
     include_file_path = os.path.join(project_root, ".vectorcode", "vectorcode.include")
     if os.path.isfile(include_file_path):
         with open(include_file_path) as fin:
-            specs = pathspec.PathSpec.from_lines(
-                pattern_factory="gitwildmatch",
+            specs = pathspec.GitIgnoreSpec.from_lines(
                 lines=(os.path.expanduser(i) for i in fin.readlines()),
             )
         return [
@@ -144,12 +143,21 @@ async def vectorise(configs: Config) -> int:
         return 1
     if not verify_ef(collection, configs):
         return 1
-    gitignore_path = os.path.join(str(configs.project_root), ".gitignore")
+
     files = await expand_globs(
         configs.files or load_files_from_include(str(configs.project_root)),
         recursive=configs.recursive,
+        include_hidden=configs.include_hidden,
     )
+
+    git_path = os.path.join(configs.project_root, ".git")
+    if os.path.isdir(git_path):
+        files = exclude_paths_by_spec(
+            (str(i) for i in files), pathspec.GitIgnoreSpec.from_lines([".git"])
+        )
+
     if not configs.force:
+        gitignore_path = os.path.join(str(configs.project_root), ".gitignore")
         specs = [
             gitignore_path,
         ]

--- a/src/vectorcode/subcommands/vectorise.py
+++ b/src/vectorcode/subcommands/vectorise.py
@@ -150,12 +150,6 @@ async def vectorise(configs: Config) -> int:
         include_hidden=configs.include_hidden,
     )
 
-    git_path = os.path.join(configs.project_root, ".git")
-    if os.path.isdir(git_path):
-        files = exclude_paths_by_spec(
-            (str(i) for i in files), pathspec.GitIgnoreSpec.from_lines([".git"])
-        )
-
     if not configs.force:
         gitignore_path = os.path.join(str(configs.project_root), ".gitignore")
         specs = [

--- a/tests/subcommands/test_vectorise.py
+++ b/tests/subcommands/test_vectorise.py
@@ -85,9 +85,7 @@ def test_show_stats_pipe_true(capsys):
 
 def test_exclude_paths_by_spec():
     paths = ["file1.py", "file2.py", "exclude.py"]
-    specs = pathspec.PathSpec.from_lines(
-        pattern_factory="gitwildmatch", lines=["exclude.py"]
-    )
+    specs = pathspec.GitIgnoreSpec.from_lines(lines=["exclude.py"])
     excluded_paths = exclude_paths_by_spec(paths, specs)
     assert "exclude.py" not in excluded_paths
     assert len(excluded_paths) == 2
@@ -95,9 +93,7 @@ def test_exclude_paths_by_spec():
 
 def test_include_paths_by_spec():
     paths = ["file1.py", "file2.py", "include.py"]
-    specs = pathspec.PathSpec.from_lines(
-        pattern_factory="gitwildmatch", lines=["include.py", "file1.py"]
-    )
+    specs = pathspec.GitIgnoreSpec.from_lines(lines=["include.py", "file1.py"])
     included_paths = include_paths_by_spec(paths, specs)
     assert "file2.py" not in included_paths
     assert len(included_paths) == 2

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -343,6 +343,26 @@ async def test_parse_cli_args_vectorise():
 
 
 @pytest.mark.asyncio
+async def test_parse_cli_args_vectorise_recursive_dir():
+    with patch("sys.argv", ["vectorcode", "vectorise", "-r", "."]):
+        config = await parse_cli_args()
+        assert config.action == CliAction.vectorise
+        assert config.files == ["."]
+        assert config.recursive is True
+        assert config.include_hidden is False
+
+
+@pytest.mark.asyncio
+async def test_parse_cli_args_vectorise_recursive_dir_include_hidden():
+    with patch("sys.argv", ["vectorcode", "vectorise", "-r", "."]):
+        config = await parse_cli_args()
+        assert config.action == CliAction.vectorise
+        assert config.files == ["."]
+        assert config.recursive is True
+        assert config.include_hidden is False
+
+
+@pytest.mark.asyncio
 async def test_parse_cli_args_vectorise_no_files():
     with patch("sys.argv", ["vectorcode", "vectorise"]):
         config = await parse_cli_args()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -215,13 +215,16 @@ async def test_async_main_cli_action_query(monkeypatch):
 @pytest.mark.asyncio
 async def test_async_main_cli_action_vectorise(monkeypatch):
     mock_cli_args = MagicMock(
-        no_stderr=False, project_root=".", action=CliAction.vectorise
+        no_stderr=False,
+        project_root=".",
+        action=CliAction.vectorise,
+        include_hidden=True,
     )
     monkeypatch.setattr(
         "vectorcode.main.parse_cli_args", AsyncMock(return_value=mock_cli_args)
     )
     mock_final_configs = MagicMock(
-        host="test_host", port=1234, action=CliAction.vectorise
+        host="test_host", port=1234, action=CliAction.vectorise, include_hidden=True
     )
     monkeypatch.setattr(
         "vectorcode.main.get_project_config",


### PR DESCRIPTION
Sometimes, a lot of the code of a project is in hidden files. There's no reason why they shouldn't be vectorised too!

As a real example, some people use GNU Stow to manage their dotfiles, and a lot of dotfiles are hidden files. For example, [my own dotfiles](https://github.com/jpmelos/dotfiles) have a lot of hidden files (and files inside a hidden directory like `.config`). I use AI assistants when working on my dotfiles constantly (especially when writing Lua code to customize Neovim). I need them to be vectorised if I want to use VectorCode while working on my own dotfiles using CodeCompanion.

(By the way, thanks for VectorCode! And for writing an integration with CodeCompanion!)