### PR TITLE
Document how to install CPU only

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,11 @@ pipx install vectorcode
 in your shell. To specify a particular version of Python, use the `--python` 
 flag. For example, `pipx install vectorcode --python python3.11`. For hardware
 accelerated embedding, refer to [the relevant section](#hardware-acceleration).
+If you want a cpu-only installation without CUDA dependences required by default by pytorch, run:
+```bash
+PIP_INDEX_URL="https://download.pytorch.org/whl/cpu" PIP_EXTRA_INDEX_URL="https://pypi.org/simple" pipx install vectorcode
+```
+
 If you need to install multiple dependency group (for [LSP](#lsp-mode) or
 [MCP](#mcp-server)), you can use the following syntax:
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,8 @@ pipx install vectorcode
 in your shell. To specify a particular version of Python, use the `--python` 
 flag. For example, `pipx install vectorcode --python python3.11`. For hardware
 accelerated embedding, refer to [the relevant section](#hardware-acceleration).
-If you want a cpu-only installation without CUDA dependences required by default by pytorch, run:
+If you want a cpu-only installation without CUDA dependences required by 
+default by pytorch, run:
 ```bash
 PIP_INDEX_URL="https://download.pytorch.org/whl/cpu" PIP_EXTRA_INDEX_URL="https://pypi.org/simple" pipx install vectorcode
 ```


### PR DESCRIPTION
By default pytorch pulls all the cuda dependencies, ending up with a ~5GB virtualenv created by pipx. If you want to use this as a neovim plugin you can have a much more lightweight installation by using cpu-only pytorch