### PR TITLE
feat(cli) : add alternative (non-utf8) encoding support.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -295,6 +295,13 @@ The JSON configuration file may hold the following values:
     "*": ["^[^a-zA-Z0-9]+$"],
   }
   ```
+- `encoding`: string, alternative encoding used for this project. By default
+  this project uses utf8. When this is set, VectorCode will decode files with the
+  specified encoding, unless you choose to override this with the `--encoding`
+  command line flag. You can also set this to `_auto`, which uses
+  [charset-normalizer](https://charset-normalizer.readthedocs.io/en/latest/index.html)
+  to automatically detect the encoding, but this is not very accurate,
+  especially on small files.
 
 ### Vectorising Your Code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "transformers>=4.36.0,!=4.51.0,!=4.51.1,!=4.51.2",
     "wheel<0.46.0",
     "colorlog",
+    "charset-normalizer>=3.4.1",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"

--- a/src/vectorcode/chunking.py
+++ b/src/vectorcode/chunking.py
@@ -147,7 +147,7 @@ class TreeSitterChunker(ChunkerBase):
     ) -> Generator[Chunk, None, None]:
         if node.text is not None:
             logger.debug(
-                f"Traversing at node {node.text.decode(encoding=self.config.encoding)} at position {node.byte_range}"
+                f"Traversing at node {node.text.decode()} at position {node.byte_range}"
             )
         current_chunk: str = ""
 
@@ -155,7 +155,7 @@ class TreeSitterChunker(ChunkerBase):
 
         for child in node.children:
             child_bytes = text_bytes[child.start_byte : child.end_byte]
-            child_text = child_bytes.decode(self.config.encoding)
+            child_text = child_bytes.decode()
             child_length = len(child_text)
 
             if child_length > self.config.chunk_size:
@@ -180,14 +180,14 @@ class TreeSitterChunker(ChunkerBase):
 
             elif not current_chunk:
                 # Start new chunk
-                current_chunk = child_bytes.decode(self.config.encoding)
+                current_chunk = child_bytes.decode()
                 current_start = Point(
                     row=child.start_point.row + 1, column=child.start_point.column
                 )
 
             elif len(current_chunk) + child_length <= self.config.chunk_size:
                 # Add to current chunk
-                current_chunk += child_bytes.decode(encoding=self.config.encoding)
+                current_chunk += child_bytes.decode()
 
             else:
                 # Yield current chunk and start new one
@@ -202,7 +202,7 @@ class TreeSitterChunker(ChunkerBase):
                         else current_start.column + len(current_chunk) - 1,
                     ),
                 )
-                current_chunk = child_bytes.decode(encoding=self.config.encoding)
+                current_chunk = child_bytes.decode()
                 current_start = Point(
                     row=child.start_point.row + 1, column=child.start_point.column
                 )
@@ -286,7 +286,7 @@ class TreeSitterChunker(ChunkerBase):
             yield from StringChunker(self.config).chunk(content)
         else:
             pattern_str = self.__build_pattern(language=language)
-            content_bytes = content.encode(encoding=self.config.encoding)
+            content_bytes = content.encode()
             tree = parser.parse(content_bytes)
             chunks_gen = self.__chunk_node(tree.root_node, content_bytes)
             if pattern_str:

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -182,6 +182,12 @@ def get_cli_parser():
         default=-1,
         help="Size of chunks (-1 for no chunking).",
     )
+    chunking_parser.add_argument(
+        "--encoding",
+        type=str,
+        default="utf8",
+        help="Encoding used by the files. See https://docs.python.org/3/library/codecs.html#standard-encodings for supported encodings.",
+    )
     shared_parser.add_argument(
         "--project_root",
         default=None,
@@ -355,6 +361,7 @@ async def parse_cli_args(args: Optional[Sequence[str]] = None):
             configs_items["force"] = main_args.force
             configs_items["chunk_size"] = main_args.chunk_size
             configs_items["overlap_ratio"] = main_args.overlap
+            configs_items["encoding"] = main_args.encoding
         case "query":
             configs_items["query"] = main_args.query
             configs_items["n_result"] = main_args.number
@@ -362,6 +369,7 @@ async def parse_cli_args(args: Optional[Sequence[str]] = None):
             configs_items["query_exclude"] = main_args.exclude
             configs_items["use_absolute_path"] = main_args.absolute
             configs_items["include"] = [QueryInclude(i) for i in main_args.include]
+            configs_items["encoding"] = main_args.encoding
         case "check":
             configs_items["check_item"] = main_args.check_item
         case "init":
@@ -370,6 +378,7 @@ async def parse_cli_args(args: Optional[Sequence[str]] = None):
             configs_items["files"] = main_args.file_paths
             configs_items["chunk_size"] = main_args.chunk_size
             configs_items["overlap_ratio"] = main_args.overlap
+            configs_items["encoding"] = main_args.encoding
     return Config(**configs_items)
 
 

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -186,7 +186,7 @@ def get_cli_parser():
         "--encoding",
         type=str,
         default="utf8",
-        help="Encoding used by the files. See https://docs.python.org/3/library/codecs.html#standard-encodings for supported encodings.",
+        help="Encoding used by the files. See https://docs.python.org/3/library/codecs.html#standard-encodings for supported encodings. Use `_auto` for automatic encoding detection.",
     )
     shared_parser.add_argument(
         "--project_root",

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -94,6 +94,7 @@ class Config:
     )
     hnsw: dict[str, str | int] = field(default_factory=dict)
     chunk_filters: dict[str, list[str]] = field(default_factory=dict)
+    encoding: str = "utf8"
 
     @classmethod
     async def import_from(cls, config_dict: dict[str, Any]) -> "Config":
@@ -142,6 +143,7 @@ class Config:
                 "chunk_filters": config_dict.get(
                     "chunk_filters", default_config.chunk_filters
                 ),
+                "encoding": config_dict.get("encoding", default_config.encoding),
             }
         )
 

--- a/src/vectorcode/subcommands/vectorise.py
+++ b/src/vectorcode/subcommands/vectorise.py
@@ -92,7 +92,7 @@ async def chunked_add(
                         documents=[str(i) for i in inserted_chunks],
                         metadatas=metas,
                     )
-    except UnicodeDecodeError:  # pragma: nocover
+    except (UnicodeDecodeError, UnicodeError):  # pragma: nocover
         logger.warning(f"Failed to decode {full_path_str}.")
         return
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -182,6 +182,29 @@ def bar():
     os.remove(test_file)
 
 
+def test_treesitter_chunker_python_auto_encoding():
+    """Test TreeSitterChunker with a sample file using tempfile."""
+    chunker = TreeSitterChunker(Config(chunk_size=30, encoding="_auto"))
+
+    test_content = r"""
+def 测试():
+    return "foo"
+
+def bar():
+    return "bar"
+    """
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", delete=False, suffix=".py", encoding="utf-16"
+    ) as tmp_file:
+        tmp_file.write(test_content)
+        test_file = tmp_file.name
+
+    chunks = list(str(i) for i in chunker.chunk(test_file))
+    assert chunks == ['def 测试():\n    return "foo"', 'def bar():\n    return "bar"']
+    os.remove(test_file)
+
+
 def test_treesitter_chunker_filter():
     chunker = TreeSitterChunker(
         Config(chunk_size=30, chunk_filters={"python": [".*foo.*"]})

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -159,6 +159,29 @@ def bar():
     os.remove(test_file)
 
 
+def test_treesitter_chunker_python_encoding():
+    """Test TreeSitterChunker with a sample file using tempfile."""
+    chunker = TreeSitterChunker(Config(chunk_size=30, encoding="gbk"))
+
+    test_content = r"""
+def 测试():
+    return "foo"
+
+def bar():
+    return "bar"
+    """
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", delete=False, suffix=".py", encoding="gbk"
+    ) as tmp_file:
+        tmp_file.write(test_content)
+        test_file = tmp_file.name
+
+    chunks = list(str(i) for i in chunker.chunk(test_file))
+    assert chunks == ['def 测试():\n    return "foo"', 'def bar():\n    return "bar"']
+    os.remove(test_file)
+
+
 def test_treesitter_chunker_filter():
     chunker = TreeSitterChunker(
         Config(chunk_size=30, chunk_filters={"python": [".*foo.*"]})

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -344,6 +344,17 @@ async def test_parse_cli_args_vectorise():
 
 
 @pytest.mark.asyncio
+async def test_parse_cli_args_vectorise_encoding():
+    with patch(
+        "sys.argv", ["vectorcode", "vectorise", "file1.txt", "--encoding", "gbk"]
+    ):
+        config = await parse_cli_args()
+        assert config.action == CliAction.vectorise
+        assert config.files == ["file1.txt"]
+        assert config.encoding == "gbk"
+
+
+@pytest.mark.asyncio
 async def test_parse_cli_args_vectorise_recursive_dir():
     with patch("sys.argv", ["vectorcode", "vectorise", "-r", "."]):
         config = await parse_cli_args()


### PR DESCRIPTION
This can be configured by `encoding` option in the json.

Need to decide what to do with mixed-encoding repos (maybe ditch the config option approach and use [this](https://charset-normalizer.readthedocs.io/en/latest/index.html)?).