### PR TITLE
feat(cli): accept json5 config.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -202,6 +202,14 @@ default global configuration will be used. If `.git/` does not exist, VectorCode
 falls back to using the current working directory as the _project root_.
 
 ### Configuring VectorCode
+Since 0.6.4, VectorCode adapted a [json5 parser](https://github.com/dpranke/pyjson5) 
+for loading configuration. VectorCode will now look for `config.json5` in
+configuration directories, and if it doesn't find one, it'll look for
+`config.json` too. Regardless of the filename extension, the json5 syntax will
+be accepted. This allows you to leave trailing comma in the config file, as well
+as writing comments (`//`). This can be very useful if you're experimenting with
+the configs.
+
 The JSON configuration file may hold the following values:
 - `embedding_function`: string, one of the embedding functions supported by [Chromadb](https://www.trychroma.com/) 
   (find more [here](https://docs.trychroma.com/docs/embeddings/embedding-functions) and 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "wheel<0.46.0",
     "colorlog",
     "charset-normalizer>=3.4.1",
+    "json5",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"

--- a/src/vectorcode/lsp_main.py
+++ b/src/vectorcode/lsp_main.py
@@ -22,7 +22,7 @@ from vectorcode.cli_utils import (
     cleanup_path,
     config_logging,
     find_project_root,
-    load_config_file,
+    get_project_config,
     parse_cli_args,
 )
 from vectorcode.common import get_client, get_collection, try_server
@@ -37,10 +37,7 @@ logger = logging.getLogger(__name__)
 async def make_caches(project_root: str):
     assert os.path.isabs(project_root)
     if cached_project_configs.get(project_root) is None:
-        config_file = os.path.join(project_root, ".vectorcode", "config.json")
-        if not os.path.isfile(config_file):
-            config_file = None
-        cached_project_configs[project_root] = await load_config_file(config_file)
+        cached_project_configs[project_root] = await get_project_config(project_root)
     config = cached_project_configs[project_root]
     config.project_root = project_root
     host, port = config.host, config.port

--- a/src/vectorcode/mcp_main.py
+++ b/src/vectorcode/mcp_main.py
@@ -151,9 +151,7 @@ async def mcp_server():
         logger.info("Found project config: %s", local_config_dir)
         project_root = str(Path(local_config_dir).parent.resolve())
 
-        default_config = await load_config_file(
-            os.path.join(project_root, ".vectorcode", "config.json")
-        )
+        default_config = await get_project_config(project_root)
         default_config.project_root = project_root
         default_client = await get_client(default_config)
         try:

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -48,8 +48,8 @@ async def test_make_caches(tmp_path):
 
     with (
         patch(
-            "vectorcode.lsp_main.load_config_file", new_callable=AsyncMock
-        ) as mock_load_config_file,
+            "vectorcode.lsp_main.get_project_config", new_callable=AsyncMock
+        ) as mock_get_project_config,
         patch(
             "vectorcode.lsp_main.try_server", new_callable=AsyncMock
         ) as mock_try_server,
@@ -57,7 +57,7 @@ async def test_make_caches(tmp_path):
         mock_try_server.return_value = True
         await make_caches(project_root)
 
-        mock_load_config_file.assert_called_once()
+        mock_get_project_config.assert_called_once_with(project_root)
         assert project_root in cached_project_configs
 
 
@@ -69,7 +69,7 @@ async def test_make_caches_server_unavailable(tmp_path):
     config_file.write_text('{"host": "test_host", "port": 9999}')
 
     with (
-        patch("vectorcode.lsp_main.load_config_file", new_callable=AsyncMock),
+        patch("vectorcode.lsp_main.get_project_config", new_callable=AsyncMock),
         patch(
             "vectorcode.lsp_main.try_server", new_callable=AsyncMock
         ) as mock_try_server,


### PR DESCRIPTION
This allows trailing comma, comments (`//`) and more!
With this PR, you can use json5 syntax directly in your `config.json` files. To make your editor (syntax checkers) happy, you may also rename the json to `config.json5` so that the linters will pick up the correct grammar.