### PR TITLE
refactor(cli): Merge hooks subcommand into init

### DIFF
--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -96,6 +96,7 @@ class Config:
     hnsw: dict[str, str | int] = field(default_factory=dict)
     chunk_filters: dict[str, list[str]] = field(default_factory=dict)
     encoding: str = "utf8"
+    hooks: bool = False
 
     @classmethod
     async def import_from(cls, config_dict: dict[str, Any]) -> "Config":
@@ -306,6 +307,12 @@ def get_cli_parser():
         action="store_true",
         default=False,
         help="Wipe current project config and overwrite with global config (if it exists).",
+    )
+    init_parser.add_argument(
+        "--hooks",
+        action="store_true",
+        default=False,
+        help="Add git hooks to the current project, if it's a git repo.",
     )
 
     subparsers.add_parser(

--- a/src/vectorcode/main.py
+++ b/src/vectorcode/main.py
@@ -63,6 +63,10 @@ async def async_main():
 
             return_val = await chunks(final_configs)
         case CliAction.hooks:
+            logger.warning(
+                "`vectorcode hooks` has been deprecated and will be removed in 0.7.0."
+            )
+            logger.warning("Please use `vectorcode init --hooks`.")
             from vectorcode.subcommands import hooks
 
             return await hooks(cli_args)

--- a/src/vectorcode/subcommands/hooks.py
+++ b/src/vectorcode/subcommands/hooks.py
@@ -1,92 +1,10 @@
-import glob
 import logging
 import os
-import platform
-import re
-import stat
-from pathlib import Path
-from typing import Optional
 
-from vectorcode.cli_utils import GLOBAL_CONFIG_PATH, Config, find_project_root
+from vectorcode.cli_utils import Config, find_project_root
+from vectorcode.subcommands.init import __HOOK_CONTENTS, HookFile, load_hooks
 
 logger = logging.getLogger(name=__name__)
-__GLOBAL_HOOKS_PATH = Path(GLOBAL_CONFIG_PATH).parent / "hooks"
-
-
-# Keys: name of the hooks, ie. `pre-commit`
-# Values: lines of the hooks.
-__HOOK_CONTENTS: dict[str, list[str]] = {
-    "pre-commit": [
-        "diff_files=$(git diff --cached --name-only)",
-        '[ -z "$diff_files" ] || vectorcode vectorise $diff_files',
-    ],
-    "post-checkout": [
-        'files=$(git diff --name-only "$1" "$2")',
-        '[ -z "$files" ] || vectorcode vectorise $files',
-    ],
-}
-
-
-def __lines_are_empty(lines: list[str]) -> bool:
-    pattern = re.compile(r"^\s*$")
-    if len(lines) == 0:
-        return True
-    return all(map(lambda line: pattern.match(line) is not None, lines))
-
-
-def load_hooks():
-    global __HOOK_CONTENTS
-    for file in glob.glob(str(__GLOBAL_HOOKS_PATH / "*")):
-        hook_name = Path(file).stem
-        with open(file) as fin:
-            lines = fin.readlines()
-            if not __lines_are_empty(lines):
-                __HOOK_CONTENTS[hook_name] = lines
-
-
-class HookFile:
-    prefix = "# VECTORCODE_HOOK_START"
-    suffix = "# VECTORCODE_HOOK_END"
-    prefix_pattern = re.compile(r"^\s*#\s*VECTORCODE_HOOK_START\s*")
-    suffix_pattern = re.compile(r"^\s*#\s*VECTORCODE_HOOK_END\s*")
-
-    def __init__(self, path: str | Path, git_dir: Optional[str | Path] = None):
-        self.path = path
-        self.lines: list[str] = []
-        if os.path.isfile(self.path):
-            with open(self.path) as fin:
-                self.lines.extend(fin.readlines())
-
-    def has_vectorcode_hooks(self, force: bool = False) -> bool:
-        for start, start_line in enumerate(self.lines):
-            if self.prefix_pattern.match(start_line) is None:
-                continue
-
-            for end in range(start + 1, len(self.lines)):
-                if self.suffix_pattern.match(self.lines[end]) is not None:
-                    if force:
-                        logger.debug("`force` cleaning existing VectorCode hooks...")
-                        new_lines = self.lines[:start] + self.lines[end + 1 :]
-                        self.lines[:] = new_lines
-                        return False
-                    logger.debug(
-                        f"Found vectorcode hook block between line {start} and {end} in {self.path}:\n{''.join(self.lines[start + 1 : end])}"
-                    )
-                    return True
-
-        return False
-
-    def inject_hook(self, content: list[str], force: bool = False):
-        if len(self.lines) == 0 or not self.has_vectorcode_hooks(force):
-            self.lines.append(self.prefix + "\n")
-            self.lines.extend(i if i.endswith("\n") else i + "\n" for i in content)
-            self.lines.append(self.suffix + "\n")
-        with open(self.path, "w") as fin:
-            fin.writelines(self.lines)
-        if platform.system() != "Windows":
-            # for unix systems, set the executable bit.
-            curr_mode = os.stat(self.path).st_mode
-            os.chmod(self.path, mode=curr_mode | stat.S_IXUSR)
 
 
 async def hooks(configs: Config) -> int:

--- a/src/vectorcode/subcommands/init.py
+++ b/src/vectorcode/subcommands/init.py
@@ -1,13 +1,98 @@
+import glob
 import logging
 import os
+import platform
+import re
 import shutil
+import stat
+from pathlib import Path
+from typing import Optional
 
-from vectorcode.cli_utils import Config
+from vectorcode.cli_utils import GLOBAL_CONFIG_PATH, Config, find_project_root
 
 logger = logging.getLogger(name=__name__)
 
+__GLOBAL_HOOKS_PATH = Path(GLOBAL_CONFIG_PATH).parent / "hooks"
+
+
+# Keys: name of the hooks, ie. `pre-commit`
+# Values: lines of the hooks.
+__HOOK_CONTENTS: dict[str, list[str]] = {
+    "pre-commit": [
+        "diff_files=$(git diff --cached --name-only)",
+        '[ -z "$diff_files" ] || vectorcode vectorise $diff_files',
+    ],
+    "post-checkout": [
+        'files=$(git diff --name-only "$1" "$2")',
+        '[ -z "$files" ] || vectorcode vectorise $files',
+    ],
+}
+
+
+def __lines_are_empty(lines: list[str]) -> bool:
+    pattern = re.compile(r"^\s*$")
+    if len(lines) == 0:
+        return True
+    return all(map(lambda line: pattern.match(line) is not None, lines))
+
+
+def load_hooks():
+    global __HOOK_CONTENTS
+    for file in glob.glob(str(__GLOBAL_HOOKS_PATH / "*")):
+        hook_name = Path(file).stem
+        with open(file) as fin:
+            lines = fin.readlines()
+            if not __lines_are_empty(lines):
+                __HOOK_CONTENTS[hook_name] = lines
+
+
+class HookFile:
+    prefix = "# VECTORCODE_HOOK_START"
+    suffix = "# VECTORCODE_HOOK_END"
+    prefix_pattern = re.compile(r"^\s*#\s*VECTORCODE_HOOK_START\s*")
+    suffix_pattern = re.compile(r"^\s*#\s*VECTORCODE_HOOK_END\s*")
+
+    def __init__(self, path: str | Path, git_dir: Optional[str | Path] = None):
+        self.path = path
+        self.lines: list[str] = []
+        if os.path.isfile(self.path):
+            with open(self.path) as fin:
+                self.lines.extend(fin.readlines())
+
+    def has_vectorcode_hooks(self, force: bool = False) -> bool:
+        for start, start_line in enumerate(self.lines):
+            if self.prefix_pattern.match(start_line) is None:
+                continue
+
+            for end in range(start + 1, len(self.lines)):
+                if self.suffix_pattern.match(self.lines[end]) is not None:
+                    if force:
+                        logger.debug("`force` cleaning existing VectorCode hooks...")
+                        new_lines = self.lines[:start] + self.lines[end + 1 :]
+                        self.lines[:] = new_lines
+                        return False
+                    logger.debug(
+                        f"Found vectorcode hook block between line {start} and {end} in {self.path}:\n{''.join(self.lines[start + 1 : end])}"
+                    )
+                    return True
+
+        return False
+
+    def inject_hook(self, content: list[str], force: bool = False):
+        if len(self.lines) == 0 or not self.has_vectorcode_hooks(force):
+            self.lines.append(self.prefix + "\n")
+            self.lines.extend(i if i.endswith("\n") else i + "\n" for i in content)
+            self.lines.append(self.suffix + "\n")
+        with open(self.path, "w") as fin:
+            fin.writelines(self.lines)
+        if platform.system() != "Windows":
+            # for unix systems, set the executable bit.
+            curr_mode = os.stat(self.path).st_mode
+            os.chmod(self.path, mode=curr_mode | stat.S_IXUSR)
+
 
 async def init(configs: Config) -> int:
+    assert configs.project_root is not None
     project_config_dir = os.path.join(str(configs.project_root), ".vectorcode")
     if os.path.isdir(project_config_dir) and not configs.force:
         logger.warning(
@@ -24,6 +109,16 @@ async def init(configs: Config) -> int:
         if os.path.isfile(global_file_path):
             logger.debug(f"Copying global {item} to {project_config_dir}")
             shutil.copyfile(global_file_path, local_file_path)
+
+    git_root = find_project_root(configs.project_root, ".git")
+    if git_root:
+        load_hooks()
+        for hook in __HOOK_CONTENTS.keys():
+            hook_file_path = os.path.join(git_root, ".git", "hooks", hook)
+            logger.info(f"Writing {hook} hook into {hook_file_path}.")
+            print(f"Processing {hook} hook...")
+            hook_obj = HookFile(hook_file_path, git_dir=git_root)
+            hook_obj.inject_hook(__HOOK_CONTENTS[hook], configs.force)
 
     print(f"VectorCode project root has been initialised at {configs.project_root}")
     print(

--- a/tests/subcommands/test_hooks.py
+++ b/tests/subcommands/test_hooks.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, call, mock_open, patch
 import pytest
 
 from vectorcode.cli_utils import Config
-from vectorcode.subcommands.hooks import HookFile, __lines_are_empty, hooks, load_hooks
+from vectorcode.subcommands.hooks import hooks
+from vectorcode.subcommands.init import HookFile, __lines_are_empty, load_hooks
 
 
 @pytest.fixture(scope="function")
@@ -15,7 +16,7 @@ def mock_hook_path() -> Path:
 
 @pytest.fixture(autouse=True, scope="function")
 def reset_hook_contents():
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
 
     original_hooks_path = __GLOBAL_HOOKS_PATH
     original_contents = __HOOK_CONTENTS.copy()
@@ -35,10 +36,10 @@ def test_lines_are_empty():
     assert not __lines_are_empty([" hello ", "\tworld"])
 
 
-@patch("vectorcode.subcommands.hooks.glob")
+@patch("vectorcode.subcommands.init.glob")
 @patch("vectorcode.subcommands.open", new_callable=mock_open)
 def test_load_hooks_no_files(mock_open_func, mock_glob):
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH
 
     mock_glob.glob.return_value = []
     expected_glob_path = str(__GLOBAL_HOOKS_PATH / "*")
@@ -49,15 +50,15 @@ def test_load_hooks_no_files(mock_open_func, mock_glob):
     mock_open_func.assert_not_called()
 
 
-@patch("vectorcode.subcommands.hooks.glob")
+@patch("vectorcode.subcommands.init.glob")
 @patch(
-    "vectorcode.subcommands.hooks.open",
+    "vectorcode.subcommands.init.open",
     new_callable=mock_open,
     read_data="Hook line 1\nLine 2",
 )
 def test_load_hooks_one_file(mock_open_func, mock_glob):
     """Test load_hooks with a single valid hook file."""
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
 
     hook_file_path = str(__GLOBAL_HOOKS_PATH / "test-hook")
     mock_glob.glob.return_value = [hook_file_path]
@@ -71,10 +72,10 @@ def test_load_hooks_one_file(mock_open_func, mock_glob):
     mock_open_func.assert_called_once_with(hook_file_path)
 
 
-@patch("vectorcode.subcommands.hooks.glob")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.glob")
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_load_hooks_multiple_files(mock_open_func, mock_glob):
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
 
     """Test load_hooks with multiple hook files."""
 
@@ -101,10 +102,10 @@ def test_load_hooks_multiple_files(mock_open_func, mock_glob):
     mock_open_func.assert_any_call(hook_file_path2)
 
 
-@patch("vectorcode.subcommands.hooks.glob")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open, read_data="")
+@patch("vectorcode.subcommands.init.glob")
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open, read_data="")
 def test_load_hooks_empty_file(mock_open_func, mock_glob):
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
 
     """Test load_hooks with an empty hook file."""
 
@@ -119,13 +120,13 @@ def test_load_hooks_empty_file(mock_open_func, mock_glob):
     mock_open_func.assert_called_once_with(hook_file_path)
 
 
-@patch("vectorcode.subcommands.hooks.glob")
+@patch("vectorcode.subcommands.init.glob")
 @patch(
-    "vectorcode.subcommands.hooks.open", new_callable=mock_open, read_data="\n   \n\t\n"
+    "vectorcode.subcommands.init.open", new_callable=mock_open, read_data="\n   \n\t\n"
 )
 def test_load_hooks_whitespace_file(mock_open_func, mock_glob):
     """Test load_hooks with a hook file containing only whitespace."""
-    from vectorcode.subcommands.hooks import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __GLOBAL_HOOKS_PATH, __HOOK_CONTENTS
 
     hook_file_path = str(__GLOBAL_HOOKS_PATH / "whitespace-hook")
     mock_glob.glob.return_value = [hook_file_path]
@@ -140,7 +141,7 @@ def test_load_hooks_whitespace_file(mock_open_func, mock_glob):
 
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
 @patch(
-    "vectorcode.subcommands.hooks.open",
+    "vectorcode.subcommands.init.open",
     new_callable=mock_open,
     read_data="Existing line 1\nExisting line 2",
 )
@@ -157,7 +158,7 @@ def test_hookfile_init_existing_file(mock_open_func, mock_isfile, mock_hook_path
 
 
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_hookfile_init_non_existent_file(mock_open_func, mock_isfile, mock_hook_path):
     """Test HookFile initialization when the hook file does not exist."""
     mock_isfile.return_value = False
@@ -217,7 +218,7 @@ def test_hookfile_init_non_existent_file(mock_open_func, mock_isfile, mock_hook_
     ],
 )
 @patch("vectorcode.subcommands.hooks.os.path.isfile", return_value=True)
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_hookfile_has_vectorcode_hooks(
     mock_open_func, mock_isfile, lines, expected, mock_hook_path
 ):
@@ -229,11 +230,11 @@ def test_hookfile_has_vectorcode_hooks(
     assert hook_file.has_vectorcode_hooks() == expected
 
 
-@patch("vectorcode.subcommands.hooks.platform.system")
+@patch("vectorcode.subcommands.init.platform.system")
 @patch("vectorcode.subcommands.hooks.os.chmod")
 @patch("vectorcode.subcommands.hooks.os.stat")
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_hookfile_inject_hook_new_file(
     mock_open_func, mock_isfile, mock_stat, mock_chmod, mock_platform, mock_hook_path
 ):
@@ -264,12 +265,12 @@ def test_hookfile_inject_hook_new_file(
     mock_chmod.assert_called_once_with(mock_hook_path, mode=expected_mode)
 
 
-@patch("vectorcode.subcommands.hooks.platform.system")
+@patch("vectorcode.subcommands.init.platform.system")
 @patch("vectorcode.subcommands.hooks.os.chmod")
 @patch("vectorcode.subcommands.hooks.os.stat")
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
 @patch(
-    "vectorcode.subcommands.hooks.open",
+    "vectorcode.subcommands.init.open",
     new_callable=mock_open,
     read_data="Existing line 1\n",
 )
@@ -310,11 +311,11 @@ def test_hookfile_inject_hook_existing_file_no_vc_hooks(
     mock_chmod.assert_not_called()
 
 
-@patch("vectorcode.subcommands.hooks.platform.system")
+@patch("vectorcode.subcommands.init.platform.system")
 @patch("vectorcode.subcommands.hooks.os.chmod")
 @patch("vectorcode.subcommands.hooks.os.stat")
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_hookfile_inject_hook_existing_file_with_vc_hooks(
     mock_open_func, mock_isfile, mock_stat, mock_chmod, mock_platform, mock_hook_path
 ):
@@ -367,7 +368,7 @@ def test_hookfile_inject_hook_existing_file_with_vc_hooks(
 
 @pytest.mark.asyncio
 @patch("vectorcode.subcommands.hooks.find_project_root", return_value=None)
-@patch("vectorcode.subcommands.hooks.load_hooks")
+@patch("vectorcode.subcommands.init.load_hooks")
 async def test_hooks_orchestration_no_git_repo(mock_load_hooks, mock_find_project_root):
     """Test hooks orchestration: handles no git repo found."""
     mock_config = Config(project_root="/some/path")
@@ -387,7 +388,7 @@ async def test_hooks_orchestration_default_hooks(
     mock_HookFile, mock_load_hooks, mock_find_project_root
 ):
     """Test hooks orchestration: handles git repo found but no hooks loaded."""
-    from vectorcode.subcommands.hooks import __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __HOOK_CONTENTS
 
     __HOOK_CONTENTS.clear()
     __HOOK_CONTENTS.update(
@@ -453,7 +454,7 @@ async def test_hooks_orchestration_with_hooks(
     mock_HookFile.return_value = mock_hook_instance
 
     with patch.dict(
-        "vectorcode.subcommands.hooks.__HOOK_CONTENTS", defined_hooks, clear=True
+        "vectorcode.subcommands.init.__HOOK_CONTENTS", defined_hooks, clear=True
     ):
         return_code = await hooks(mock_config)
 
@@ -475,7 +476,7 @@ async def test_hooks_orchestration_with_hooks(
 
 @patch("vectorcode.subcommands.hooks.os.path.isfile", return_value=True)
 @patch(
-    "vectorcode.subcommands.hooks.open",
+    "vectorcode.subcommands.init.open",
     new_callable=mock_open,
 )
 def test_hookfile_has_vectorcode_hooks_force_removes_block(
@@ -509,11 +510,11 @@ def test_hookfile_has_vectorcode_hooks_force_removes_block(
     assert hook_file.lines == expected_lines_after  # Check if block was removed
 
 
-@patch("vectorcode.subcommands.hooks.platform.system")
+@patch("vectorcode.subcommands.init.platform.system")
 @patch("vectorcode.subcommands.hooks.os.chmod")
 @patch("vectorcode.subcommands.hooks.os.stat")
 @patch("vectorcode.subcommands.hooks.os.path.isfile")
-@patch("vectorcode.subcommands.hooks.open", new_callable=mock_open)
+@patch("vectorcode.subcommands.init.open", new_callable=mock_open)
 def test_hookfile_inject_hook_force_overwrites_existing(
     mock_open_func, mock_isfile, mock_stat, mock_chmod, mock_platform, mock_hook_path
 ):
@@ -582,7 +583,7 @@ async def test_hooks_orchestration_force_true(
     mock_HookFile, mock_load_hooks, mock_find_project_root
 ):
     """Test hooks orchestration passes force=True to HookFile.inject_hook."""
-    from vectorcode.subcommands.hooks import __HOOK_CONTENTS
+    from vectorcode.subcommands.init import __HOOK_CONTENTS
 
     # Ensure there's some hook content defined for the test
     defined_hooks = {"pre-commit": ["echo pre-commit"]}

--- a/tests/subcommands/test_init.py
+++ b/tests/subcommands/test_init.py
@@ -31,7 +31,7 @@ async def test_init_already_initialized(capsys):
 
         # Try to initialize again without force
         return_code = await init(configs)
-        assert return_code == 1
+        assert return_code != 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
most of the times, hooks only need to be set up once for each repo, so it makes sense to merge it with `init`.