### PR TITLE
feat(cli) Fallback to primary language name when tree_sitter_language_pack won't find a parser for 'hybrid' lexer language names (like 'javascript+genshitext')

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -324,6 +324,19 @@ The JSON configuration file may hold the following values:
     "hnsw:construction_ef": 100
   }
   ```
+- `filetype_map`: `dict[str, list[str]]`, a dictionary where keys are
+    [language name](https://github.com/Goldziher/tree-sitter-language-pack?tab=readme-ov-file#available-languages)
+    and values are lists of [Python regex patterns](https://docs.python.org/3/library/re.html)
+    that will match file extensions. This allows overriding automatic language
+    detection and specifying a treesitter parser for certain file types for which the language parser cannot be
+    correctly identified (e.g., `.phtml` files containing both php and html).
+    Example configuration:
+    ```json5
+    "filetype_map": {
+      "php": ["^phtml$"]
+    }
+    ```
+
 - `chunk_filters`: `dict[str, list[str]]`, a dictionary where the keys are
   [language name](https://github.com/Goldziher/tree-sitter-language-pack?tab=readme-ov-file#available-languages)
   and values are lists of [Python regex patterns](https://docs.python.org/3/library/re.html) 

--- a/src/vectorcode/chunking.py
+++ b/src/vectorcode/chunking.py
@@ -304,11 +304,11 @@ class TreeSitterChunker(ChunkerBase):
                         logger.debug(f"Found parser for language '{language}' from config.")
                         return parser
                 except re.error as e:
-                    logger.error(f"Invalid regex pattern '{pattern}' for language '{language}' in filetype_map: {e}")
-                    raise ValueError(f"Invalid regex pattern '{pattern}' for language '{language}' in filetype_map: {e}")
-                except LookupError:
-                    logger.error(f"Configured parser for language '{language}' not found or failed to load. Please check your filetype_map config.")
-                    raise ValueError(f"Configured parser for language '{language}' not found.") from None
+                    e.add_note(f"\nInvalid regex pattern '{pattern}' for language '{language}' in filetype_map")
+                    raise
+                except LookupError as e:
+                    e.add_note(f"\nTreeSitter Parser for language '{language}' not found. Please check your filetype_map config.")
+                    raise
 
         logger.debug(f"No matching filetype map entry found for {filename}.")
         return None

--- a/src/vectorcode/chunking.py
+++ b/src/vectorcode/chunking.py
@@ -309,6 +309,11 @@ class TreeSitterChunker(ChunkerBase):
                         break
                 except LookupError:  # pragma: nocover
                     pass
+                if '+' in name:
+                    primary_name = name.split('+')[0]
+                    if primary_name not in lang_names:
+                        lang_names.append(primary_name)
+                        logger.debug("Added primary lang_name: %s to the list of lang_names to test", primary_name)
 
         if parser is None:
             logger.debug(

--- a/src/vectorcode/chunking.py
+++ b/src/vectorcode/chunking.py
@@ -301,17 +301,14 @@ class TreeSitterChunker(ChunkerBase):
                     if re.search(pattern, extension):
                         logger.debug(f"'{filename}' extension matches pattern '{pattern}' for language '{language}'. Attempting to load parser.")
                         parser = get_parser(language)
-                        if parser is None:
-                            raise LookupError(f"Parser not found for language '{language}'. Please check your filetype_map config.")
                         logger.debug(f"Found parser for language '{language}' from config.")
                         return parser
                 except re.error as e:
                     logger.error(f"Invalid regex pattern '{pattern}' for language '{language}' in filetype_map: {e}")
+                    raise ValueError(f"Invalid regex pattern '{pattern}' for language '{language}' in filetype_map: {e}")
                 except LookupError:
                     logger.error(f"Configured parser for language '{language}' not found or failed to load. Please check your filetype_map config.")
                     raise ValueError(f"Configured parser for language '{language}' not found.") from None
-                except Exception as e:
-                    logger.error(f"An unexpected error occurred while processing filetype_map for language '{language}' and pattern '{pattern}': {e}")
 
         logger.debug(f"No matching filetype map entry found for {filename}.")
         return None

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -94,6 +94,7 @@ class Config:
     )
     hnsw: dict[str, str | int] = field(default_factory=dict)
     chunk_filters: dict[str, list[str]] = field(default_factory=dict)
+    filetype_map: dict[str, list[str]] = field(default_factory=dict)
     encoding: str = "utf8"
     hooks: bool = False
 
@@ -155,6 +156,9 @@ class Config:
                 "hnsw": config_dict.get("hnsw", default_config.hnsw),
                 "chunk_filters": config_dict.get(
                     "chunk_filters", default_config.chunk_filters
+                ),
+                "filetype_map": config_dict.get(
+                    "filetype_map", default_config.filetype_map
                 ),
                 "encoding": config_dict.get("encoding", default_config.encoding),
             }

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -223,6 +223,50 @@ def bar():
     assert chunks == ['def 测试():\n    return "foo"', 'def bar():\n    return "bar"']
     os.remove(test_file)
 
+def test_treesitter_chunker_javascript():
+    """Test TreeSitterChunker with a sample javascript file using tempfile."""
+    chunker = TreeSitterChunker(Config(chunk_size=60))
+
+    test_content = r"""
+function foo() {
+    return "foo";
+}
+
+function bar() {
+    return "bar";
+}
+    """
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".js") as tmp_file:
+        tmp_file.write(test_content)
+        test_file = tmp_file.name
+
+    chunks = list(str(i) for i in chunker.chunk(test_file))
+    assert chunks == ['function foo() {\n    return "foo";\n}', 'function bar() {\n    return "bar";\n}']
+    os.remove(test_file)
+
+def test_treesitter_chunker_javascript_genshi():
+    """Test TreeSitterChunker with a sample javascript + genshi file using tempfile."""
+    chunker = TreeSitterChunker(Config(chunk_size=60))
+
+    test_content = r"""
+function foo() {
+    return `foo with ${genshi}`;
+}
+
+function bar() {
+    return "bar";
+}
+    """
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".js") as tmp_file:
+        tmp_file.write(test_content)
+        test_file = tmp_file.name
+
+    chunks = list(str(i) for i in chunker.chunk(test_file))
+    assert chunks == ['function foo() {\n    return `foo with ${genshi}`;\n}', 'function bar() {\n    return "bar";\n}']
+    os.remove(test_file)
+
 
 def test_treesitter_chunker_filter():
     chunker = TreeSitterChunker(

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -288,6 +288,7 @@ function bar() {
 
     with pytest.raises(ValueError):
         chunks = list(str(i) for i in chunker.chunk(test_file))
+        assert chunks == []
     os.remove(test_file)
 
 def test_treesitter_chunker_parser_from_config_regex_error():
@@ -311,6 +312,7 @@ function bar() {
 
     with pytest.raises(ValueError):
         chunks = list(str(i) for i in chunker.chunk(test_file))
+        assert chunks == []
     os.remove(test_file)
 
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -286,7 +286,7 @@ function bar() {
         test_file = tmp_file.name
 
 
-    with pytest.raises(Exception):
+    with pytest.raises(LookupError):
         chunks = list(str(i) for i in chunker.chunk(test_file))
         assert chunks == []
     os.remove(test_file)

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -286,7 +286,7 @@ function bar() {
         test_file = tmp_file.name
 
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         chunks = list(str(i) for i in chunker.chunk(test_file))
         assert chunks == []
     os.remove(test_file)
@@ -310,7 +310,7 @@ function bar() {
         test_file = tmp_file.name
 
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         chunks = list(str(i) for i in chunker.chunk(test_file))
         assert chunks == []
     os.remove(test_file)

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -246,8 +246,9 @@ function bar() {
     os.remove(test_file)
 
 def test_treesitter_chunker_javascript_genshi():
-    """Test TreeSitterChunker with a sample javascript + genshi file using tempfile."""
-    chunker = TreeSitterChunker(Config(chunk_size=60))
+    """Test TreeSitterChunker with a sample javascript + genshi file using tempfile. (bypassing lexers via the filetype_map config param)"""
+    chunker = TreeSitterChunker(Config(chunk_size=60, filetype_map={"javascript": ["^kid$"]}))
+    # chunker = TreeSitterChunker(Config(chunk_size=60))
 
     test_content = r"""
 function foo() {
@@ -259,7 +260,7 @@ function bar() {
 }
     """
 
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".js") as tmp_file:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".kid") as tmp_file:
         tmp_file.write(test_content)
         test_file = tmp_file.name
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -315,6 +315,28 @@ function bar() {
         assert chunks == []
     os.remove(test_file)
 
+def test_treesitter_chunker_parser_from_config_no_language_match():
+    """Test TreeSitterChunker filetype_map: should continue with the lexer parser checks if no language matches a regex"""
+    chunker = TreeSitterChunker(Config(chunk_size=60, filetype_map={"php": ["^jsx$"]}))
+
+    test_content = r"""
+function foo() {
+    return "foo";
+}
+
+function bar() {
+    return "bar";
+}
+    """
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".js") as tmp_file:
+        tmp_file.write(test_content)
+        test_file = tmp_file.name
+
+    chunks = list(str(i) for i in chunker.chunk(test_file))
+    assert chunks == ['function foo() {\n    return "foo";\n}', 'function bar() {\n    return "bar";\n}']
+    os.remove(test_file)
+
 
 
 def test_treesitter_chunker_filter():


### PR DESCRIPTION
If for example you have a javascript file containing patterns like: '${placeholder}', the pygments.lexers's guess_lexer_for_filename function will return the  'JavaScript+Genshi Text' lexer.

This is because this lexer has the '.js' extension in his list of 'alias_filenames'. And since you have a pattern matching the \$\{.*?\} regexp in your content, this lexer will get a higher score than the primary 'javascript' lexer and thus be returned by the guess_lexer_for_filename method.

Probably none of the lexers from the 'pygments.lexers.templates' module (joining two language by a '+' symbol. like: javascript+genshitext, html+ng2, css+django,...) will find a parser from tree_sitter_language_pack.

The chunker will then fallback to the naive chunking method.

In these scenarios, we likely want to find the parser of our primary language (which would be for the above examples: 'javascript', 'html' or 'css') instead of falling back for the naive chunking method.

A solution might be to replace the call of the pygments.lexers's 'guess_lexer_for_filename' function by the 'get_lexer_for_filename' function which only compares lexers that have a 'primary' filename matching your file extension (and not the alias_filenames) but I went for a maybe more safe solution which is to continue to check for the existence of a parser for this 'hybrid' language name' and then fallback to the primary language name (the name before the '+' sign) in last ressort.