### PR TITLE
refactor(cli): use `db_url` to replace `host` and `port`.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -261,10 +261,9 @@ The JSON configuration file may hold the following values:
   Then the embedding function object will be initialised as
   `OllamaEmbeddingFunction(url="http://127.0.0.1:11434/api/embeddings",
   model_name="nomic-embed-text")`. Default: `{}`;
-- `host` and `port`: string and integer, Chromadb server host and port. VectorCode will start an
+- `db_url`: string, the url that points to the Chromadb server. VectorCode will start an
   HTTP server for Chromadb at a randomly picked free port on `localhost` if your 
-  configured `host:port` is not accessible. This allows the use of `AsyncHttpClient`. 
-  Default: `127.0.0.1:8000`;
+  configured `http://host:port` is not accessible. Default: `http://127.0.0.1:8000`;
 - `db_path`: string, Path to local persistent database. This is where the files for 
   your database will be stored. Default: `~/.local/share/vectorcode/chromadb/`;
 - `db_log_path`: string, path to the _directory_ where the built-in chromadb

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -109,12 +109,13 @@ class Config:
             host = config_dict.get("host")
             port = config_dict.get("port")
             if host is not None or port is not None:
-                logger.warning(
-                    '"host" and "port" are deprecated. Use "db_url" (eg. http://127.0.0.1:8000).'
-                )
+                # TODO: deprecate `host` and `port` in 0.7.0
                 host = host or "127.0.0.1"
                 port = port or 8000
                 db_url = f"http://{host}:{port}"
+                logger.warning(
+                    f'"host" and "port" are deprecated and will be removed in 0.7.0. Use "db_url" (eg. {db_url}).'
+                )
             else:
                 db_url = "http://127.0.0.1:8000"
 

--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -73,8 +73,7 @@ class Config:
     files: list[PathLike] = field(default_factory=list)
     project_root: Optional[PathLike] = None
     query: Optional[list[str]] = None
-    host: str = "127.0.0.1"
-    port: int = 8000
+    db_url: str = "http://127.0.0.1:8000"
     embedding_function: str = "SentenceTransformerEmbeddingFunction"  # This should fallback to whatever the default is.
     embedding_params: dict[str, Any] = field(default_factory=(lambda: {}))
     n_result: int = 1
@@ -105,8 +104,20 @@ class Config:
         """
         default_config = Config()
         db_path = config_dict.get("db_path")
-        host = config_dict.get("host") or "localhost"
-        port = config_dict.get("port") or 8000
+        db_url = config_dict.get("db_url")
+        if db_url is None:
+            host = config_dict.get("host")
+            port = config_dict.get("port")
+            if host is not None or port is not None:
+                logger.warning(
+                    '"host" and "port" are deprecated. Use "db_url" (eg. http://127.0.0.1:8000).'
+                )
+                host = host or "127.0.0.1"
+                port = port or 8000
+                db_url = f"http://{host}:{port}"
+            else:
+                db_url = "http://127.0.0.1:8000"
+
         if db_path is None:
             db_path = os.path.expanduser("~/.local/share/vectorcode/chromadb/")
         elif not os.path.isdir(db_path):
@@ -121,8 +132,7 @@ class Config:
                 "embedding_params": config_dict.get(
                     "embedding_params", default_config.embedding_params
                 ),
-                "host": host,
-                "port": port,
+                "db_url": db_url,
                 "db_path": db_path,
                 "db_log_path": os.path.expanduser(
                     config_dict.get("db_log_path", default_config.db_log_path)

--- a/src/vectorcode/main.py
+++ b/src/vectorcode/main.py
@@ -74,7 +74,7 @@ async def async_main():
     from vectorcode.common import start_server, try_server
 
     server_process = None
-    if not await try_server(final_configs.host, final_configs.port):
+    if not await try_server(final_configs.db_url):
         server_process = await start_server(final_configs)
 
     if final_configs.pipe:

--- a/tests/subcommands/test_vectorise.py
+++ b/tests/subcommands/test_vectorise.py
@@ -268,8 +268,7 @@ def test_load_files_from_include_no_files(mock_check_tree_files, mock_isfile, tm
 @pytest.mark.asyncio
 async def test_vectorise(capsys):
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -330,8 +329,7 @@ async def test_vectorise(capsys):
 @pytest.mark.asyncio
 async def test_vectorise_cancelled():
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -373,8 +371,7 @@ async def test_vectorise_cancelled():
 @pytest.mark.asyncio
 async def test_vectorise_orphaned_files():
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -443,8 +440,7 @@ async def test_vectorise_orphaned_files():
 @pytest.mark.asyncio
 async def test_vectorise_collection_index_error():
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -470,8 +466,7 @@ async def test_vectorise_collection_index_error():
 @pytest.mark.asyncio
 async def test_vectorise_verify_ef_false():
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -500,8 +495,7 @@ async def test_vectorise_verify_ef_false():
 @pytest.mark.asyncio
 async def test_vectorise_gitignore():
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},
@@ -548,8 +542,7 @@ async def test_vectorise_exclude_file(tmpdir):
     exclude_file.write("excluded_file.py\n")
 
     configs = Config(
-        host="test_host",
-        port=1234,
+        db_url="http://test_host:1234",
         db_path="test_db",
         embedding_function="SentenceTransformerEmbeddingFunction",
         embedding_params={},


### PR DESCRIPTION
This allows users to use a chromadb server behind a reverse proxy (`http://your.host.name:8000/your/chroma`) and/or chromadb with HTTPS encryption (`https://your.host.name:8001`). The updated documentation will also address #140. 

This PR supercedes #142 .