### PR TITLE
feat(cli,nvim): add nix flake and option to specify cli_cmds in nvim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # VectorCode
 src/vectorcode/_version.py
+
+# nix
+result

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -137,6 +137,10 @@ This function initialises the VectorCode client and sets up some default
 ```lua
 -- Default configuration
 require("vectorcode").setup({
+  cli_cmds = {
+    vectorcode = "vectorcode",
+    vectorcode_server = "vectorcode-server",
+  },
   async_opts = {
     debounce = 10,
     events = { "BufWritePost", "InsertEnter", "BufReadPost" },
@@ -160,6 +164,10 @@ require("vectorcode").setup({
 ```
 
 The following are the available options for the parameter of this function:
+- `cli_cmds`: A table to customize the CLI command names / paths used by the plugin.
+  Supported keys:
+  - `vectorcode`: The command / path to use for the main CLI tool. Default: `"vectorcode"`.
+  - `vectorcode_server`: The command / path to use for the server component. Default: `"vectorcode-server"`.
 - `n_query`: number of retrieved documents. A large number gives a higher chance
   of including the right file, but with the risk of saturating the context 
   window and getting truncated. Default: `1`;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,249 @@
+{
+  description = "VectorCode";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      nixpkgs,
+      self,
+      ...
+    }@inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # INFO: This is a workaround until newer versions of the `chromadb` package are available
+        chromadb = pkgs.python312Packages.buildPythonPackage rec {
+          pname = "chromadb";
+          version = "0.6.3";
+          pyproject = true;
+
+          src = pkgs.fetchFromGitHub {
+            owner = "chroma-core";
+            repo = "chroma";
+            tag = version;
+            hash = "sha256-yvAX8buETsdPvMQmRK5+WFz4fVaGIdNlfhSadtHwU5U=";
+          };
+
+          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+            inherit src;
+            name = "${pname}-${version}";
+            hash = "sha256-lHRBXJa/OFNf4x7afEJw9XcuDveTBIy3XpQ3+19JXn4=";
+          };
+
+          pythonRelaxDeps = [
+            "chroma-hnswlib"
+            "orjson"
+          ];
+
+          build-system = with pkgs.python312Packages; [
+            setuptools
+            setuptools-scm
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            cargo
+            pkg-config
+            protobuf
+            rustc
+            rustPlatform.cargoSetupHook
+          ];
+
+          buildInputs = with pkgs; [
+            openssl
+            zstd
+          ];
+
+          dependencies = with pkgs.python312Packages; [
+            bcrypt
+            build
+            chroma-hnswlib
+            fastapi
+            grpcio
+            httpx
+            importlib-resources
+            kubernetes
+            mmh3
+            numpy
+            onnxruntime
+            opentelemetry-api
+            opentelemetry-exporter-otlp-proto-grpc
+            opentelemetry-instrumentation-fastapi
+            opentelemetry-sdk
+            orjson
+            overrides
+            posthog
+            pulsar-client
+            pydantic
+            pypika
+            pyyaml
+            requests
+            tenacity
+            tokenizers
+            tqdm
+            typer
+            typing-extensions
+            uvicorn
+          ];
+
+          nativeCheckInputs = with pkgs.python312Packages; [
+            hypothesis
+            psutil
+            pytest-asyncio
+            pytestCheckHook
+          ];
+
+          pythonImportsCheck = [ "chromadb" ];
+
+          env = {
+            ZSTD_SYS_USE_PKG_CONFIG = true;
+          };
+
+          pytestFlagsArray = [ "-x" ];
+
+          preCheck = ''
+            (($(ulimit -n) < 1024)) && ulimit -n 1024
+            export HOME=$(mktemp -d)
+          '';
+
+          doCheck = false;
+
+          __darwinAllowLocalNetworking = true;
+
+          meta = with pkgs.lib; {
+            description = "AI-native open-source embedding database";
+            homepage = "https://github.com/chroma-core/chroma";
+            changelog = "https://github.com/chroma-core/chroma/releases/tag/${version}";
+            license = licenses.asl20;
+            maintainers = with maintainers; [ fab ];
+            mainProgram = "chroma";
+            broken = pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch64;
+          };
+        };
+
+        pkgVersion = "0.5.6";
+
+        vectorcode = pkgs.python312Packages.buildPythonApplication rec {
+          pname = "vectorcode";
+          version = pkgVersion;
+          format = "pyproject";
+
+          src = self;
+
+          nativeBuildInputs = with pkgs; [
+            python312Packages.pdm-backend
+            makeWrapper
+            installShellFiles
+          ];
+
+          propagatedBuildInputs = with pkgs.python312Packages; [
+            chromadb
+            httpx
+            numpy
+            pathspec
+            psutil
+            pygments
+            sentence-transformers
+            shtab
+            tabulate
+            transformers
+            tree-sitter
+            tree-sitter-language-pack
+            google-api-python-client
+            colorlog
+            json5
+            lsprotocol
+            pygls
+          ];
+
+          optional-dependencies = with pkgs.python312Packages; {
+            intel = [
+              openvino
+              optimum
+            ];
+            legacy = [
+              numpy
+              torch
+              transformers
+            ];
+            lsp = [
+              lsprotocol
+              pygls
+            ];
+            mcp = [
+              mcp
+              pydantic
+            ];
+          };
+
+          pythonImportsCheck = [ "vectorcode" ];
+
+          nativeCheckInputs = with pkgs.python312Packages; [
+            mcp
+            pygls
+            pytestCheckHook
+            pytest-asyncio
+          ];
+          versionCheckProgramArg = "version";
+
+          postFixup = ''
+            # INFO: Workaround for subprocesses
+            wrapProgram $out/bin/vectorcode \
+              --prefix PYTHONPATH : "$PYTHONPATH"
+            wrapProgram $out/bin/vectorcode-server \
+              --prefix PYTHONPATH : "$PYTHONPATH"
+            wrapProgram $out/bin/vectorcode-mcp-server \
+              --prefix PYTHONPATH : "$PYTHONPATH"
+          '';
+
+          postInstall = ''
+            installShellCompletion --cmd vectorcode \
+              --bash <($out/bin/vectorcode --print-completion bash) \
+              --zsh <($out/bin/vectorcode --print-completion zsh)
+            installShellCompletion --cmd vectorcode-server \
+              --bash <($out/bin/vectorcode --print-completion bash) \
+              --zsh <($out/bin/vectorcode --print-completion zsh)
+            installShellCompletion --cmd vectorcode-mcp-server \
+              --bash <($out/bin/vectorcode --print-completion bash) \
+              --zsh <($out/bin/vectorcode --print-completion zsh)
+          '';
+
+          disabledTests = [
+            # Require internet access
+            "test_get_embedding_function"
+            "test_get_embedding_function_fallback"
+            "test_reranker"
+            "test_common"
+          ];
+
+          meta = {
+            description = "Code repository indexing tool to supercharge your LLM experience";
+            homepage = "https://github.com/Davidyz/VectorCode";
+            changelog = "https://github.com/Davidyz/VectorCode/releases/tag/${version}";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "vectorcode";
+          };
+        };
+      in
+      {
+        packages = {
+          default = vectorcode;
+
+          vimPlugin = pkgs.vimUtils.buildVimPlugin {
+            pname = "VectorCode";
+            version = pkgVersion;
+            src = self;
+            dependencies = [
+              pkgs.vimPlugins.plenary-nvim
+            ];
+            patches = pkgs.replaceVars ./nix/vim-plugin.patch {
+              inherit vectorcode;
+            };
+          };
+        };
+      }
+    );
+}

--- a/lua/vectorcode/cacher/default.lua
+++ b/lua/vectorcode/cacher/default.lua
@@ -1,6 +1,7 @@
 ---@type VectorCode.CacheBackend
 local M = {}
 local vc_config = require("vectorcode.config")
+local vectorcode_cli_cmd = vc_config.get_user_config().cli_cmds.vectorcode
 local notify_opts = vc_config.notify_opts
 local jobrunner = require("vectorcode.jobrunner.cmd")
 

--- a/lua/vectorcode/cacher/lsp.lua
+++ b/lua/vectorcode/cacher/lsp.lua
@@ -1,6 +1,7 @@
 ---@type VectorCode.CacheBackend
 local M = {}
 local vc_config = require("vectorcode.config")
+local vectorcode_cli_cmd = vc_config.get_user_config().cli_cmds.vectorcode
 local logger = vc_config.logger
 
 local notify_opts = vc_config.notify_opts

--- a/lua/vectorcode/config.lua
+++ b/lua/vectorcode/config.lua
@@ -15,6 +15,10 @@ local cacher = nil
 
 ---@type VectorCode.Opts
 local config = {
+  cli_cmds = {
+    vectorcode = "vectorcode",
+    vectorcode_server = "vectorcode-server",
+  },
   async_opts = {
     debounce = 10,
     events = { "BufWritePost", "InsertEnter", "BufReadPost" },
@@ -24,6 +28,7 @@ local config = {
     query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1),
     run_on_register = false,
     single_job = false,
+    timeout_ms = 5000,
   },
   async_backend = "default",
   exclude_this = true,
@@ -35,12 +40,14 @@ local config = {
 }
 
 local setup_config = vim.deepcopy(config, true)
+local vectorcode_cli_cmd = setup_config.cli_cmds.vectorcode
+local vectorcode_server_cli_cmd = setup_config.cli_cmds.vectorcode_server
 
 ---@return vim.lsp.ClientConfig
 local lsp_configs = function()
   ---@type vim.lsp.ClientConfig
   local cfg =
-    { cmd = { "vectorcode-server" }, root_markers = { ".vectorcode", ".git" } }
+    { cmd = { vectorcode_server_cli_cmd }, root_markers = { ".vectorcode", ".git" } }
   if vim.lsp.config ~= nil and vim.lsp.config.vectorcode_server ~= nil then
     -- nvim >= 0.11.0
     cfg = vim.tbl_deep_extend("force", cfg, vim.lsp.config.vectorcode_server)
@@ -73,7 +80,7 @@ local notify_opts = { title = "VectorCode" }
 ---@param opts {notify:boolean}?
 local has_cli = function(opts)
   opts = opts or { notify = false }
-  local ok = vim.fn.executable("vectorcode") == 1
+  local ok = vim.fn.executable(vectorcode_cli_cmd) == 1
   if not ok and opts.notify then
     vim.notify("VectorCode CLI is not executable!", vim.log.levels.ERROR, notify_opts)
   end

--- a/lua/vectorcode/jobrunner/cmd.lua
+++ b/lua/vectorcode/jobrunner/cmd.lua
@@ -4,6 +4,8 @@ local runner = {}
 local Job = require("plenary.job")
 ---@type {integer: Job}
 local jobs = {}
+local vectorcode_cli_cmd =
+  require("vectorcode.config").get_user_config().cli_cmds.vectorcode
 local logger = require("vectorcode.config").logger
 
 function runner.run_async(args, callback, bufnr)
@@ -12,15 +14,12 @@ function runner.run_async(args, callback, bufnr)
   else
     callback = nil
   end
-  local cmd = { "vectorcode" }
-  args = require("vectorcode.jobrunner").find_root(args, bufnr)
-  vim.list_extend(cmd, args)
   logger.debug(
     ("cmd jobrunner for buffer %s args: %s"):format(bufnr, vim.inspect(args))
   )
   ---@diagnostic disable-next-line: missing-fields
   local job = Job:new({
-    command = "vectorcode",
+    command = vectorcode_cli_cmd,
     args = args,
     on_exit = function(self, code, signal)
       jobs[self.pid] = nil

--- a/lua/vectorcode/jobrunner/lsp.lua
+++ b/lua/vectorcode/jobrunner/lsp.lua
@@ -1,6 +1,11 @@
+local vectorcode_server_cli_cmd =
+  require("vectorcode.config").get_user_config().cli_cmds.vectorcode_server
+local vectorcode_cli_cmd =
+  require("vectorcode.config").get_user_config().cli_cmds.vectorcode
+
 if
-  vim.fn.executable("vectorcode-server") ~= 1
-  or vim.system({ "vectorcode-server", "--version" }):wait().code ~= 0
+  vim.fn.executable(vectorcode_server_cli_cmd) ~= 1
+  or vim.system({ vectorcode_server_cli_cmd, "--version" }):wait().code ~= 0
 then
   return nil
 end
@@ -93,7 +98,7 @@ function jobrunner.run_async(args, callback, bufnr)
   )
   local _, id = CLIENT:request(
     vim.lsp.protocol.Methods.workspace_executeCommand,
-    { command = "vectorcode", arguments = args },
+    { command = vectorcode_cli_cmd, arguments = args },
     function(err, result, _, _)
       if type(callback) == "function" then
         local err_message = {}

--- a/lua/vectorcode/types.lua
+++ b/lua/vectorcode/types.lua
@@ -23,9 +23,14 @@
 ---@field update boolean `vectorcode update`
 ---@field lsp boolean whether to start LSP server on startup (default is to delay it to the first LSP request)
 
+---@class VectorCode.CliCmds Cli commands to use
+---@field vectorcode string vectorcode cli command or full path
+---@field vectorcode_server string vectorcode-server cli command or full path
+
 ---Options passed to `setup`.
 ---@class VectorCode.Opts : VectorCode.QueryOpts
 ---@field async_opts VectorCode.RegisterOpts Default options to use for registering a new buffer for async cache.
+---@field cli_cmds VectorCode.CliCmds
 ---@field on_setup VectorCode.OnSetup
 ---@field async_backend "default"|"lsp"
 ---@field sync_log_env_var boolean Whether to automatically set `VECTORCODE_LOG_LEVEL` when `VECTORCODE_NVIM_LOG_LEVEL` is detected. !! WARNING: THIS MAY RESULT IN EXCESSIVE LOG MESSAGES DUE TO STDERR BEING POPULATED BY CLI LOGS

--- a/nix/vim-plugin.patch
+++ b/nix/vim-plugin.patch
@@ -1,0 +1,15 @@
+diff --git a/lua/vectorcode/config.lua b/lua/vectorcode/config.lua
+index 247e93b..c6036b5 100644
+--- a/lua/vectorcode/config.lua
++++ b/lua/vectorcode/config.lua
+@@ -16,8 +16,8 @@ local cacher = nil
+ ---@type VectorCode.Opts
+ local config = {
+   cli_cmds = {
+-    vectorcode = "vectorcode",
+-    vectorcode_server = "vectorcode-server",
++    vectorcode = "@vectorcode@/bin/vectorcode",
++    vectorcode_server = "@vectorcode@/bin/vectorcode-server",
+   },
+   async_opts = {
+     debounce = 10,

--- a/src/vectorcode/lsp_main.py
+++ b/src/vectorcode/lsp_main.py
@@ -7,6 +7,8 @@ import time
 import traceback
 import uuid
 
+import shtab
+
 try:  # pragma: nocover
     from lsprotocol import types
     from pygls.exceptions import (
@@ -63,6 +65,12 @@ def get_arg_parser():
         help="Default project root for VectorCode queries.",
         type=str,
         default="",
+    )
+    shtab.add_argument_to(
+        parser,
+        ["-s", "--print-completion"],
+        parent=parser,
+        help="Print completion script.",
     )
     return parser
 

--- a/src/vectorcode/mcp_main.py
+++ b/src/vectorcode/mcp_main.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+import shtab
 from chromadb.api import AsyncClientAPI
 from chromadb.api.models.AsyncCollection import AsyncCollection
 from chromadb.errors import InvalidCollectionException
@@ -59,6 +60,12 @@ def get_arg_parser():
         action="store_true",
         default=False,
         help="Whether to include the output of `vectorcode ls` in the tool description.",
+    )
+    shtab.add_argument_to(
+        parser,
+        ["-s", "--print-completion"],
+        parent=parser,
+        help="Print completion script.",
     )
     return parser
 


### PR DESCRIPTION
This PR introduces a Nix flake. To ensure Nix works correctly, it also updates the Neovim plugin to support specifying `cli_cmds`, which are later patched by Nix to point directly to the Nix store. Both changes are included in this PR.