### PR TITLE
fix(chunking): Fallback to StringChunker for Tree-sitter nodes with no children

### DIFF
--- a/src/vectorcode/chunking.py
+++ b/src/vectorcode/chunking.py
@@ -141,6 +141,7 @@ class TreeSitterChunker(ChunkerBase):
         if config is None:
             config = Config()
         super().__init__(config)
+        self._fallback_chunker = StringChunker(config)
 
     def __chunk_node(
         self, node: Node, text_bytes: bytes
@@ -155,10 +156,9 @@ class TreeSitterChunker(ChunkerBase):
 
         logger.debug("nbr children: %s", len(node.children))
         # if node has no children we fallback to the string chunker
-        if len(node.children) == 0:
+        if len(node.children) == 0 and node.text:
             logger.debug("No children, falling back to string chunker")
-            yield from StringChunker(self.config).chunk(node.text.decode())
-
+            yield from self._fallback_chunker.chunk(node.text.decode())
 
         for child in node.children:
             child_bytes = text_bytes[child.start_byte : child.end_byte]
@@ -314,7 +314,7 @@ class TreeSitterChunker(ChunkerBase):
             logger.debug(
                 "Unable to pick a suitable parser. Fall back to naive chunking"
             )
-            yield from StringChunker(self.config).chunk(content)
+            yield from self._fallback_chunker.chunk(content)
         else:
             pattern_str = self.__build_pattern(language=language)
             content_bytes = content.encode()


### PR DESCRIPTION
When a Tree-sitter node has no children, the TreeSitterChunker would previously not yield any chunks for its content. This change adds a check for nodes with no children and falls back to using the StringChunker on the node's text, ensuring the content is processed.

This is for example useful for files containing embedded content that the primary treesitter parser can't process. For example in Vue3 SFC components (.vue) you can have embedded javascript logic within a <setup> tag and then your html template. The parser will parse the html part but will only see one 'RawText' node for  the embedded javascript code. If this part is longer then your configured chunk_size, it won't be returned at all by the TreeSitterChunker since this node has no children.

With this fix, the embedded content will fallback to the naive chunking, which is probably way better than being completly ignored

In my neovim environment I somehow managed to have Treesitter be able to parse the embedded content in .vue files but here, for the TreeSitterChunker, the treesiter 'Vue' grammar apparently is not responsible of handling the embedded content (I guess my nvim-treesitter plugin does some magic to merge multiple treesitter parsers for these kind of embedded content....)