### PR TITLE
refactor(cli, nvim): add exit code to job runners.

### DIFF
--- a/lua/vectorcode/cacher/default.lua
+++ b/lua/vectorcode/cacher/default.lua
@@ -313,21 +313,14 @@ end
 ---@param on_success fun(out: vim.SystemCompleted)?
 ---@param on_failure fun(out: vim.SystemCompleted?)?
 function M.async_check(check_item, on_success, on_failure)
-  if not vc_config.has_cli() then
-    if on_failure ~= nil then
-      on_failure()
-    end
-    return
-  end
-
-  check_item = check_item or "config"
-  vim.system({ "vectorcode", "check", check_item }, {}, function(out)
-    if out.code == 0 and type(on_success) == "function" then
-      vim.schedule_wrap(on_success)(out)
-    elseif out.code ~= 0 and type(on_failure) == "function" then
-      vim.schedule_wrap(on_failure)(out)
-    end
-  end)
+  vim.deprecate(
+    "vectorcode.cacher.default.async_check",
+    "vectorcode.cacher.utils.async_check",
+    "0.7.0",
+    "VectorCode",
+    true
+  )
+  require("vectorcode.cacher").utils.async_check(check_item, on_success, on_failure)
 end
 
 ---@param bufnr integer?

--- a/lua/vectorcode/cacher/init.lua
+++ b/lua/vectorcode/cacher/init.lua
@@ -1,4 +1,36 @@
+local vc_config = require("vectorcode.config")
+local jobrunner = require("vectorcode.jobrunner.cmd")
+
 return {
   lsp = require("vectorcode.cacher.lsp"),
   default = require("vectorcode.cacher.default"),
+  utils = {
+    ---Checks if VectorCode has been configured properly for your project.
+    ---See the CLI manual for details.
+    ---@param check_item string?
+    ---@param on_success fun(out: vim.SystemCompleted)?
+    ---@param on_failure fun(out: vim.SystemCompleted?)?
+    async_check = function(check_item, on_success, on_failure)
+      if not vc_config.has_cli() then
+        if on_failure ~= nil then
+          on_failure()
+        end
+        return
+      end
+      check_item = check_item or "config"
+      jobrunner.run_async({ "check", check_item }, function(result, error, code, signal)
+        local out = {
+          stdout = table.concat(vim.iter(result):flatten(math.huge):totable()),
+          stderr = table.concat(vim.iter(error):flatten(math.huge):totable()),
+          code = code,
+          signal = signal,
+        }
+        if out.code == 0 and type(on_success) == "function" then
+          vim.schedule_wrap(on_success)(out)
+        elseif out.code ~= 0 and type(on_failure) == "function" then
+          vim.schedule_wrap(on_failure)(out)
+        end
+      end, 0)
+    end,
+  },
 }

--- a/lua/vectorcode/cacher/lsp.lua
+++ b/lua/vectorcode/cacher/lsp.lua
@@ -348,21 +348,14 @@ end
 ---@param on_success fun(out: vim.SystemCompleted)?
 ---@param on_failure fun(out: vim.SystemCompleted?)?
 function M.async_check(check_item, on_success, on_failure)
-  if not vc_config.has_cli() then
-    if on_failure ~= nil then
-      on_failure()
-    end
-    return
-  end
-
-  check_item = check_item or "config"
-  vim.system({ "vectorcode", "check", check_item }, {}, function(out)
-    if out.code == 0 and type(on_success) == "function" then
-      vim.schedule_wrap(on_success)(out)
-    elseif out.code ~= 0 and type(on_failure) == "function" then
-      vim.schedule_wrap(on_failure)(out)
-    end
-  end)
+  vim.deprecate(
+    "vectorcode.cacher.default.async_check",
+    "vectorcode.cacher.utils.async_check",
+    "0.7.0",
+    "VectorCode",
+    true
+  )
+  require("vectorcode.cacher").utils.async_check(check_item, on_success, on_failure)
 end
 
 ---@param bufnr integer?

--- a/lua/vectorcode/init.lua
+++ b/lua/vectorcode/init.lua
@@ -186,14 +186,17 @@ function M.check(check_item, stdout_cb)
   end
   check_item = check_item or "config"
   local return_code
-  vim
-    .system({ "vectorcode", "check", check_item }, {}, function(out)
-      return_code = out.code
-      if type(stdout_cb) == "function" then
-        stdout_cb(out)
-      end
-    end)
-    :wait()
+  jobrunner.run_async({ "check", check_item }, function(result, error, code, signal)
+    return_code = code
+    if type(stdout_cb) == "function" then
+      stdout_cb({
+        stdout = table.concat(vim.iter(result):flatten(math.huge):totable()),
+        stderr = table.concat(vim.iter(error):flatten(math.huge):totable()),
+        code = code,
+        signal = signal,
+      })
+    end
+  end, 0)
   return return_code == 0
 end
 

--- a/lua/vectorcode/jobrunner/cmd.lua
+++ b/lua/vectorcode/jobrunner/cmd.lua
@@ -43,7 +43,7 @@ function runner.run_async(args, callback, bufnr)
             )
           end
         else
-          callback({ result }, self:stderr_result())
+          callback({ result }, self:stderr_result(), code, signal)
           logger.warn("cmd runner: failed to decode result:\n", result)
         end
       end

--- a/lua/vectorcode/jobrunner/init.lua
+++ b/lua/vectorcode/jobrunner/init.lua
@@ -6,15 +6,23 @@ local utils = require("vectorcode.utils")
 ---@class VectorCode.JobRunner
 --- Runs a vectorcode command asynchronously.
 --- Executes the command specified by `args`. Upon completion, if `callback` is provided,
---- it's invoked with the result table (decoded JSON from stdout) and error table (stderr lines).
+--- it's invoked with the following arguments:
+--- - `result`: the JSON object of the command execution result.
+--- - `error`: error messages, if any.
+--- - `code`: exit code (or error code) for the process.
+--- - `signal`: _for cmd runner only_, the shell signal sent to the process.
 --- The `bufnr` is used for context, potentially to find the project root or attach LSP clients.
 --- Returns a job handle (e.g., PID or LSP request ID) or nil if the job couldn't be started.
----@field run_async fun(args: string[], callback:fun(result: table, error: table, code:integer)?, bufnr: integer):(job_handle:integer?)
+---@field run_async fun(args: string[], callback:fun(result: table, error: table, code:integer, signal: integer?)?, bufnr: integer):(job_handle:integer?)
 --- Runs a vectorcode command synchronously, blocking until completion or timeout.
 --- Executes the command specified by `args`. Waits for up to `timeout_ms` milliseconds.
 --- The `bufnr` is used for context, potentially to find the project root or attach LSP clients.
---- Returns the result table (decoded JSON from stdout) and error table (stderr lines).
----@field run fun(args: string[], timeout_ms: integer?, bufnr: integer):(result:table, error:table, code:integer)
+--- Returns the following objects:
+--- - `result`: the JSON object of the command execution result.
+--- - `error`: error messages, if any.
+--- - `code`: exit code (or error code) for the process.
+--- - `signal`: _for cmd runner only_, the shell signal sent to the process.
+---@field run fun(args: string[], timeout_ms: integer?, bufnr: integer):(result:table, error:table, code:integer, signal: integer?)
 --- Checks if a job associated with the given handle is currently running.
 --- Returns true if the job is running, false otherwise.
 ---@field is_job_running fun(job_handle: integer):boolean

--- a/lua/vectorcode/jobrunner/init.lua
+++ b/lua/vectorcode/jobrunner/init.lua
@@ -9,12 +9,12 @@ local utils = require("vectorcode.utils")
 --- it's invoked with the result table (decoded JSON from stdout) and error table (stderr lines).
 --- The `bufnr` is used for context, potentially to find the project root or attach LSP clients.
 --- Returns a job handle (e.g., PID or LSP request ID) or nil if the job couldn't be started.
----@field run_async fun(args: string[], callback:fun(result: table, error: table)?, bufnr: integer):(job_handle:integer?)
+---@field run_async fun(args: string[], callback:fun(result: table, error: table, code:integer)?, bufnr: integer):(job_handle:integer?)
 --- Runs a vectorcode command synchronously, blocking until completion or timeout.
 --- Executes the command specified by `args`. Waits for up to `timeout_ms` milliseconds.
 --- The `bufnr` is used for context, potentially to find the project root or attach LSP clients.
 --- Returns the result table (decoded JSON from stdout) and error table (stderr lines).
----@field run fun(args: string[], timeout_ms: integer?, bufnr: integer):(result:table, error:table)
+---@field run fun(args: string[], timeout_ms: integer?, bufnr: integer):(result:table, error:table, code:integer)
 --- Checks if a job associated with the given handle is currently running.
 --- Returns true if the job is running, false otherwise.
 ---@field is_job_running fun(job_handle: integer):boolean

--- a/lua/vectorcode/jobrunner/lsp.lua
+++ b/lua/vectorcode/jobrunner/lsp.lua
@@ -52,18 +52,16 @@ function jobrunner.run(args, timeout_ms, bufnr)
   end
   args = require("vectorcode.jobrunner").find_root(args, bufnr)
 
-  local result, err
-  jobrunner.run_async(args, function(res, err)
+  local result, err, code
+  jobrunner.run_async(args, function(res, err, e_code)
     result = res
     err = err
+    code = e_code
   end, bufnr)
   vim.wait(timeout_ms, function()
     return (result ~= nil) or (err ~= nil)
   end)
-  if result == nil then
-    return {}, err
-  end
-  return result, err
+  return result or {}, err, code
 end
 
 function jobrunner.run_async(args, callback, bufnr)
@@ -102,7 +100,7 @@ function jobrunner.run_async(args, callback, bufnr)
         if err ~= nil and err.message ~= nil then
           err_message = { err.message }
         end
-        vim.schedule_wrap(callback)(result, err_message)
+        vim.schedule_wrap(callback)(result, err_message, err.code)
         if result then
           logger.debug(
             "lsp jobrunner result:\n",

--- a/lua/vectorcode/jobrunner/lsp.lua
+++ b/lua/vectorcode/jobrunner/lsp.lua
@@ -100,7 +100,11 @@ function jobrunner.run_async(args, callback, bufnr)
         if err ~= nil and err.message ~= nil then
           err_message = { err.message }
         end
-        vim.schedule_wrap(callback)(result, err_message, err.code)
+        local code = 0
+        if err and err.code then
+          code = err.code
+        end
+        vim.schedule_wrap(callback)(result, err_message, code)
         if result then
           logger.debug(
             "lsp jobrunner result:\n",

--- a/src/vectorcode/lsp_main.py
+++ b/src/vectorcode/lsp_main.py
@@ -6,7 +6,11 @@ import sys
 import time
 import uuid
 
-from pygls.exceptions import JsonRpcInvalidRequest
+from pygls.exceptions import (
+    JsonRpcException,
+    JsonRpcInternalError,
+    JsonRpcInvalidRequest,
+)
 
 try:  # pragma: nocover
     from lsprotocol import types
@@ -68,89 +72,101 @@ server: LanguageServer = LanguageServer(name="vectorcode-server", version=__vers
 
 @server.command("vectorcode")
 async def execute_command(ls: LanguageServer, args: list[str]):
-    global DEFAULT_PROJECT_ROOT
-    start_time = time.time()
-    logger.info("Received command arguments: %s", args)
-    parsed_args = await parse_cli_args(args)
-    logger.info("Parsed command arguments: %s", parsed_args)
-    if parsed_args.action not in {CliAction.query, CliAction.ls}:
-        error_message = f"Unsupported vectorcode subcommand: {str(parsed_args.action)}"
-        logger.error(
-            error_message,
-        )
-        raise JsonRpcInvalidRequest(error_message)
-    if parsed_args.project_root is None:
-        if DEFAULT_PROJECT_ROOT is not None:
-            parsed_args.project_root = DEFAULT_PROJECT_ROOT
-            logger.warning("Using DEFAULT_PROJECT_ROOT: %s", DEFAULT_PROJECT_ROOT)
-    elif DEFAULT_PROJECT_ROOT is None:
-        logger.warning("Updating DEFAULT_PROJECT_ROOT to %s", parsed_args.project_root)
-        DEFAULT_PROJECT_ROOT = str(parsed_args.project_root)
-
-    if parsed_args.project_root is not None:
-        parsed_args.project_root = os.path.abspath(str(parsed_args.project_root))
-        await make_caches(parsed_args.project_root)
-        final_configs = await cached_project_configs[
-            parsed_args.project_root
-        ].merge_from(parsed_args)
-        final_configs.pipe = True
-        client = await get_client(final_configs)
-        collection = await get_collection(
-            client=client,
-            configs=final_configs,
-            make_if_missing=final_configs.action in {CliAction.vectorise},
-        )
-    else:
-        final_configs = parsed_args
-        client = await get_client(parsed_args)
-        collection = None
-    logger.info("Merged final configs: %s", final_configs)
-    progress_token = str(uuid.uuid4())
-
-    await ls.progress.create_async(progress_token)
-    match final_configs.action:
-        case CliAction.query:
-            ls.progress.begin(
-                progress_token,
-                types.WorkDoneProgressBegin(
-                    "VectorCode",
-                    message=f"Querying {cleanup_path(str(final_configs.project_root))}",
-                ),
+    try:
+        global DEFAULT_PROJECT_ROOT
+        start_time = time.time()
+        logger.info("Received command arguments: %s", args)
+        parsed_args = await parse_cli_args(args)
+        logger.info("Parsed command arguments: %s", parsed_args)
+        if parsed_args.action not in {CliAction.query, CliAction.ls}:
+            error_message = (
+                f"Unsupported vectorcode subcommand: {str(parsed_args.action)}"
             )
-            final_results = []
-            try:
-                if collection is None:
-                    print("Please specify a project to search in.", file=sys.stderr)
-                else:
-                    final_results.extend(
-                        await build_query_results(collection, final_configs)
+            logger.error(
+                error_message,
+            )
+            raise JsonRpcInvalidRequest(error_message)
+        if parsed_args.project_root is None:
+            if DEFAULT_PROJECT_ROOT is not None:
+                parsed_args.project_root = DEFAULT_PROJECT_ROOT
+                logger.warning("Using DEFAULT_PROJECT_ROOT: %s", DEFAULT_PROJECT_ROOT)
+        elif DEFAULT_PROJECT_ROOT is None:
+            logger.warning(
+                "Updating DEFAULT_PROJECT_ROOT to %s", parsed_args.project_root
+            )
+            DEFAULT_PROJECT_ROOT = str(parsed_args.project_root)
+
+        if parsed_args.project_root is not None:
+            parsed_args.project_root = os.path.abspath(str(parsed_args.project_root))
+            await make_caches(parsed_args.project_root)
+            final_configs = await cached_project_configs[
+                parsed_args.project_root
+            ].merge_from(parsed_args)
+            final_configs.pipe = True
+            client = await get_client(final_configs)
+            collection = await get_collection(
+                client=client,
+                configs=final_configs,
+                make_if_missing=final_configs.action in {CliAction.vectorise},
+            )
+        else:
+            final_configs = parsed_args
+            client = await get_client(parsed_args)
+            collection = None
+        logger.info("Merged final configs: %s", final_configs)
+        progress_token = str(uuid.uuid4())
+
+        await ls.progress.create_async(progress_token)
+        match final_configs.action:
+            case CliAction.query:
+                ls.progress.begin(
+                    progress_token,
+                    types.WorkDoneProgressBegin(
+                        "VectorCode",
+                        message=f"Querying {cleanup_path(str(final_configs.project_root))}",
+                    ),
+                )
+                final_results = []
+                try:
+                    if collection is None:
+                        print("Please specify a project to search in.", file=sys.stderr)
+                    else:
+                        final_results.extend(
+                            await build_query_results(collection, final_configs)
+                        )
+                finally:
+                    log_message = f"Retrieved {len(final_results)} result{'s' if len(final_results) > 1 else ''} in {round(time.time() - start_time, 2)}s."
+                    ls.progress.end(
+                        progress_token,
+                        types.WorkDoneProgressEnd(message=log_message),
                     )
-            finally:
-                log_message = f"Retrieved {len(final_results)} result{'s' if len(final_results) > 1 else ''} in {round(time.time() - start_time, 2)}s."
-                ls.progress.end(
+                    logger.info(log_message)
+                return final_results
+            case CliAction.ls:
+                ls.progress.begin(
                     progress_token,
-                    types.WorkDoneProgressEnd(message=log_message),
+                    types.WorkDoneProgressBegin(
+                        "VectorCode",
+                        message="Looking for other projects indexed by VectorCode",
+                    ),
                 )
-                logger.info(log_message)
-            return final_results
-        case CliAction.ls:
-            ls.progress.begin(
-                progress_token,
-                types.WorkDoneProgressBegin(
-                    "VectorCode",
-                    message="Looking for other projects indexed by VectorCode",
-                ),
-            )
-            projects: list[dict] = []
-            try:
-                projects.extend(await get_collection_list(client))
-            finally:
-                ls.progress.end(
-                    progress_token,
-                    types.WorkDoneProgressEnd(message="List retrieved."),
-                )
-                logger.info(f"Retrieved {len(projects)} project(s).")
-            return projects
+                projects: list[dict] = []
+                try:
+                    projects.extend(await get_collection_list(client))
+                finally:
+                    ls.progress.end(
+                        progress_token,
+                        types.WorkDoneProgressEnd(message="List retrieved."),
+                    )
+                    logger.info(f"Retrieved {len(projects)} project(s).")
+                return projects
+    except Exception as e:
+        if isinstance(e, JsonRpcException):
+            # pygls exception. raise it as is.
+            raise
+        else:  # pragma: nocover
+            # wrap non-pygls errors for error codes.
+            raise JsonRpcInternalError(e.__traceback__) from e
 
 
 async def lsp_start() -> int:

--- a/src/vectorcode/lsp_main.py
+++ b/src/vectorcode/lsp_main.py
@@ -6,6 +6,8 @@ import sys
 import time
 import uuid
 
+from pygls.exceptions import JsonRpcInvalidRequest
+
 try:  # pragma: nocover
     from lsprotocol import types
     from pygls.server import LanguageServer
@@ -72,11 +74,11 @@ async def execute_command(ls: LanguageServer, args: list[str]):
     parsed_args = await parse_cli_args(args)
     logger.info("Parsed command arguments: %s", parsed_args)
     if parsed_args.action not in {CliAction.query, CliAction.ls}:
-        print(
-            f"Unsupported vectorcode subcommand: {str(parsed_args.action)}",
-            file=sys.stderr,
+        error_message = f"Unsupported vectorcode subcommand: {str(parsed_args.action)}"
+        logger.error(
+            error_message,
         )
-        return
+        raise JsonRpcInvalidRequest(error_message)
     if parsed_args.project_root is None:
         if DEFAULT_PROJECT_ROOT is not None:
             parsed_args.project_root = DEFAULT_PROJECT_ROOT

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pygls.exceptions import JsonRpcInvalidRequest
 from pygls.server import LanguageServer
 
 from vectorcode import __version__
@@ -245,9 +246,8 @@ async def test_execute_command_unsupported_action(
         # Mock the merge_from method
         mock_config.merge_from = AsyncMock(return_value=mock_config)
 
-        await execute_command(mock_language_server, ["invalid_action"])
-        captured = capsys.readouterr()
-        assert "Unsupported vectorcode subcommand" in captured.err
+        with pytest.raises(JsonRpcInvalidRequest):
+            await execute_command(mock_language_server, ["invalid_action"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR aims to eliminate all usage of `vim.system` and/or `plenary.job` outside of jobrunners.

Also, this PR improved error handling of the LSP server so that the error codes follow the LSP specification.