### PR TITLE
Allow the codecompanion tool to send chunks instead of full documents.

### DIFF
--- a/doc/VectorCode.txt
+++ b/doc/VectorCode.txt
@@ -167,30 +167,34 @@ This function initialises the VectorCode client and sets up some default
 
 >lua
     -- Default configuration
-    require("vectorcode").setup({
-      cli_cmds = {
-        vectorcode = "vectorcode",
-      },
-      async_opts = {
-        debounce = 10,
-        events = { "BufWritePost", "InsertEnter", "BufReadPost" },
+    require("vectorcode").setup(
+      ---@type VectorCode.Opts
+      {
+        cli_cmds = {
+          vectorcode = "vectorcode",
+        },
+        ---@type VectorCode.RegisterOpts
+        async_opts = {
+          debounce = 10,
+          events = { "BufWritePost", "InsertEnter", "BufReadPost" },
+          exclude_this = true,
+          n_query = 1,
+          notify = false,
+          query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1),
+          run_on_register = false,
+        },
+        async_backend = "default", -- or "lsp"
         exclude_this = true,
         n_query = 1,
-        notify = false,
-        query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1),
-        run_on_register = false,
-      },
-      async_backend = "default", -- or "lsp"
-      exclude_this = true,
-      n_query = 1,
-      notify = true,
-      timeout_ms = 5000,
-      on_setup = {
-        update = false, -- set to true to enable update when `setup` is called.
-        lsp = false,
+        notify = true,
+        timeout_ms = 5000,
+        on_setup = {
+          update = false, -- set to true to enable update when `setup` is called.
+          lsp = false,
+        }
+        sync_log_env_var = false,
       }
-      sync_log_env_var = false,
-    })
+    )
 <
 
 The following are the available options for the parameter of this function: -

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -141,30 +141,34 @@ This function initialises the VectorCode client and sets up some default
 
 ```lua
 -- Default configuration
-require("vectorcode").setup({
-  cli_cmds = {
-    vectorcode = "vectorcode",
-  },
-  async_opts = {
-    debounce = 10,
-    events = { "BufWritePost", "InsertEnter", "BufReadPost" },
+require("vectorcode").setup(
+  ---@type VectorCode.Opts
+  {
+    cli_cmds = {
+      vectorcode = "vectorcode",
+    },
+    ---@type VectorCode.RegisterOpts
+    async_opts = {
+      debounce = 10,
+      events = { "BufWritePost", "InsertEnter", "BufReadPost" },
+      exclude_this = true,
+      n_query = 1,
+      notify = false,
+      query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1),
+      run_on_register = false,
+    },
+    async_backend = "default", -- or "lsp"
     exclude_this = true,
     n_query = 1,
-    notify = false,
-    query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1),
-    run_on_register = false,
-  },
-  async_backend = "default", -- or "lsp"
-  exclude_this = true,
-  n_query = 1,
-  notify = true,
-  timeout_ms = 5000,
-  on_setup = {
-    update = false, -- set to true to enable update when `setup` is called.
-    lsp = false,
+    notify = true,
+    timeout_ms = 5000,
+    on_setup = {
+      update = false, -- set to true to enable update when `setup` is called.
+      lsp = false,
+    }
+    sync_log_env_var = false,
   }
-  sync_log_env_var = false,
-})
+)
 ```
 
 The following are the available options for the parameter of this function:

--- a/lua/vectorcode/integrations/codecompanion/common.lua
+++ b/lua/vectorcode/integrations/codecompanion/common.lua
@@ -5,12 +5,13 @@ local logger = vc_config.logger
 
 ---@class VectorCode.CodeCompanion.ToolOpts
 ---@field max_num integer?
----@field default_num integer?
+---@field default_num integer|{document:integer, chunk: integer}|nil
 ---@field include_stderr boolean?
 ---@field use_lsp boolean?
 ---@field auto_submit table<string, boolean>?
 ---@field ls_on_start boolean?
 ---@field no_duplicate boolean?
+---@field chunk_mode boolean?
 
 return {
   tool_result_source = "VectorCodeToolResult",
@@ -23,6 +24,31 @@ return {
     return table.concat(vim.iter(t):flatten(math.huge):totable(), "\n")
   end,
 
+  ---@param result VectorCode.Result
+  ---@return string
+  process_result = function(result)
+    if result.chunk then
+      -- chunk mode
+      local chunk =
+        string.format("<path>%s</path><chunk>%s</chunk>", result.path, result.chunk)
+      if result.start_line and result.end_line then
+        chunk = chunk
+          .. string.format(
+            "<start_line>%d</start_line><end_line>%d</end_line>",
+            result.start_line,
+            result.end_line
+          )
+      end
+      return chunk
+    else
+      -- full document mode
+      return string.format(
+        "<path>%s</path><content>%s</content>",
+        result.path,
+        result.document
+      )
+    end
+  end,
   ---@param use_lsp boolean
   ---@return VectorCode.JobRunner
   initialise_runner = function(use_lsp)

--- a/lua/vectorcode/integrations/codecompanion/common.lua
+++ b/lua/vectorcode/integrations/codecompanion/common.lua
@@ -4,7 +4,7 @@ local notify_opts = vc_config.notify_opts
 local logger = vc_config.logger
 
 ---@class VectorCode.CodeCompanion.ToolOpts
----@field max_num integer?
+---@field max_num integer|{document:integer, chunk: integer}|nil
 ---@field default_num integer|{document:integer, chunk: integer}|nil
 ---@field include_stderr boolean?
 ---@field use_lsp boolean?
@@ -55,6 +55,17 @@ return {
       assert(
         type(opts.default_num) == "number",
         "default_num should be an integer or a table: {chunk: integer, document: integer}"
+      )
+    end
+    if type(opts.max_num) == "table" then
+      if opts.chunk_mode then
+        opts.max_num = opts.max_num.chunk
+      else
+        opts.max_num = opts.max_num.document
+      end
+      assert(
+        type(opts.max_num) == "number",
+        "max_num should be an integer or a table: {chunk: integer, document: integer}"
       )
     end
     return vim.tbl_deep_extend("force", default_options, opts)

--- a/lua/vectorcode/integrations/codecompanion/func_calling_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/func_calling_tool.lua
@@ -11,6 +11,10 @@ local job_runner = nil
 ---@return CodeCompanion.Agent.Tool
 return check_cli_wrap(function(opts)
   opts = cc_common.get_tool_opts(opts)
+  assert(
+    type(opts.max_num) == "number" and type(opts.default_num) == "number",
+    string.format("Options are not correctly formatted:%s", vim.inspect(opts))
+  )
   ---@type "file"|"chunk"
   local mode
   if opts.chunk_mode then

--- a/lua/vectorcode/integrations/codecompanion/func_calling_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/func_calling_tool.lua
@@ -191,7 +191,7 @@ return check_cli_wrap(function(opts)
     system_prompt = function()
       local guidelines = {
         "  - The path of a retrieved file will be wrapped in `<path>` and `</path>` tags. Its content will be right after the `</path>` tag, wrapped by `<content>` and `</content>` tags. Do not include the `<path>``</path>` tags in your answers when you mention the paths.",
-        "  - The results may also be chunks of the source code. In this case, the text chunks will be wrapped in <chunk></chunk>. If the starting and ending line ranges are available, they will be wrapped in <start_line></start_line> and <end_line></end_line> tags. Make use of them when you're quoting the source code.",
+        "  - The results may also be chunks of the source code. In this case, the text chunks will be wrapped in <chunk></chunk>. If the starting and ending line ranges are available, they will be wrapped in <start_line></start_line> and <end_line></end_line> tags. Make use of the line numbers (NOT THE XML TAGS) when you're quoting the source code.",
         "  - If you used the tool, tell users that they may need to wait for the results and there will be a virtual text indicator showing the tool is still running",
         "  - Include one single command call for VectorCode each time. You may include multiple keywords in the command",
         "  - VectorCode is the name of this tool. Do not include it in the query unless the user explicitly asks",

--- a/lua/vectorcode/types.lua
+++ b/lua/vectorcode/types.lua
@@ -1,7 +1,10 @@
 ---Type definition of the retrieval result.
 ---@class VectorCode.Result
 ---@field path string Path to the file
----@field document string Content of the file
+---@field document string? Content of the file
+---@field chunk string?
+---@field start_line integer?
+---@field end_line integer?
 
 ---Type definitions for the cache of a buffer.
 ---@class VectorCode.Cache

--- a/lua/vectorcode/types.lua
+++ b/lua/vectorcode/types.lua
@@ -56,3 +56,30 @@
 ---@field buf_is_enabled fun(bufnr: integer?): boolean Checks if a buffer has been enabled.
 ---@field make_prompt_component fun(bufnr: integer?, component_cb: (fun(result: VectorCode.Result): string)?): {content: string, count: integer} Compile the retrieval results into a string.
 ---@field async_check fun(check_item: string?, on_success: fun(out: vim.SystemCompleted)?, on_failure: fun(out: vim.SystemCompleted)?) Checks if VectorCode has been configured properly for your project.
+
+--- This class defines the options available to the CodeCompanion tool.
+---@class VectorCode.CodeCompanion.ToolOpts
+--- Maximum number of results provided to the LLM.
+--- You may set this to a table to configure different values for document/chunk mode.
+--- When set to negative values, it means unlimited.
+--- Default: `{ document = -1, chunk = -1 }`
+---@field max_num integer|{document:integer, chunk: integer}|nil
+--- Default number of results provided to the LLM.
+--- This value is written in the system prompt and tool description.
+--- Users may ask the LLM to request a different number of results in the chat.
+--- You may set this to a table to configure different values for document/chunk mode.
+--- Default: `{ document = 10, chunk = 50 }`
+---@field default_num integer|{document:integer, chunk: integer}|nil
+--- Whether the stderr should be provided back to the chat
+---@field include_stderr boolean?
+--- Whether to use the LSP backend. Default: `false`
+---@field use_lsp boolean?
+--- Whether to automatically submit the result (no longer necessary in recent CodeCompanion releases). Default: `false`
+---@field auto_submit table<string, boolean>?
+--- Whether to run `vectorcode ls` and tell the LLM about the indexed projects when initialising the tool. Default: `false`
+---@field ls_on_start boolean?
+--- Whether to avoid duplicated references. Default: `true`
+---@field no_duplicate boolean?
+--- Whether to send chunks instead of full files to the LLM. Default: `false`
+--- > Make sure you adjust `max_num` and `default_num` accordingly.
+---@field chunk_mode boolean?


### PR DESCRIPTION
Continuation of #168 , with some refactoring that make the codebase better organised as a prep for #172 