### PR TITLE
Use `chunk_id` to deduplicate chunks in codecompanion tool

### DIFF
--- a/doc/VectorCode-cli.txt
+++ b/doc/VectorCode-cli.txt
@@ -665,17 +665,21 @@ If you used `--include chunk path` parameters, the array will look like this:
             "chunk": "foo",
             "start_line": 1,
             "end_line": 1,
+            "chunk_id": "chunk_id_1"
         },
         {
             "path": "path_to_another_file.py",
             "chunk": "bar",
             "start_line": 1,
             "end_line": 1,
+            "chunk_id": "chunk_id_2"
         }
     ]
 <
 
-Keep in mind that both `start_line` and `end_line` are inclusive.
+Keep in mind that both `start_line` and `end_line` are inclusive. The
+`chunk_id` is a random string that can be used as a unique identifier to
+distinguish between chunks. These are the same IDs used in the database.
 
 
 VECTORCODE VECTORISE

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -600,16 +600,20 @@ If you used `--include chunk path` parameters, the array will look like this:
         "chunk": "foo",
         "start_line": 1,
         "end_line": 1,
+        "chunk_id": "chunk_id_1"
     },
     {
         "path": "path_to_another_file.py",
         "chunk": "bar",
         "start_line": 1,
         "end_line": 1,
+        "chunk_id": "chunk_id_2"
     }
 ]
 ```
-Keep in mind that both `start_line` and `end_line` are inclusive.
+Keep in mind that both `start_line` and `end_line` are inclusive. The `chunk_id`
+is a random string that can be used as a unique identifier to distinguish
+between chunks. These are the same IDs used in the database.
 
 #### `vectorcode vectorise`
 The output is in JSON format. It contains a dictionary with the following fields:

--- a/src/vectorcode/subcommands/query/__init__.py
+++ b/src/vectorcode/subcommands/query/__init__.py
@@ -111,7 +111,10 @@ async def build_query_results(
                 assert chunk_texts is not None, (
                     "QueryResult does not contain `documents`!"
                 )
-                full_result: dict[str, str | int] = {"chunk": str(chunk_texts[0])}
+                full_result: dict[str, str | int] = {
+                    "chunk": str(chunk_texts[0]),
+                    "chunk_id": identifier,
+                }
                 if meta[0].get("start") is not None and meta[0].get("end") is not None:
                     path = str(meta[0].get("path"))
                     with open(path) as fin:

--- a/tests/subcommands/query/test_query.py
+++ b/tests/subcommands/query/test_query.py
@@ -173,6 +173,7 @@ async def test_build_query_results_chunk_mode_success(mock_collection, mock_conf
             "chunk": expected_chunk_content,
             "start_line": start_line,
             "end_line": end_line,
+            "chunk_id": identifier,
         }
 
         assert results[0] == expected_full_result


### PR DESCRIPTION
- [x] Refactor the CLI so that the chunk id is returned in the results of the `query` subcommand
- [ ] Implement ID filtering when `chunk_mode=true` for codecompanion tool