### PR TITLE
Copy global `config.json5` during init

### DIFF
--- a/src/vectorcode/subcommands/init.py
+++ b/src/vectorcode/subcommands/init.py
@@ -102,7 +102,12 @@ async def init(configs: Config) -> int:
         is_initialised = 1
     else:
         os.makedirs(project_config_dir, exist_ok=True)
-        for item in ("config.json", "vectorcode.include", "vectorcode.exclude"):
+        for item in (
+            "config.json5",
+            "config.json",
+            "vectorcode.include",
+            "vectorcode.exclude",
+        ):
             local_file_path = os.path.join(project_config_dir, item)
             global_file_path = os.path.join(
                 os.path.expanduser("~"), ".config", "vectorcode", item

--- a/tests/subcommands/test_init.py
+++ b/tests/subcommands/test_init.py
@@ -60,6 +60,7 @@ async def test_init_copies_global_config(capsys):
         # Create mock global config files
         config_items = {
             "config.json": '{"test": "value"}',
+            "config.json5": '{"test": "value"}',
             "vectorcode.include": "*.py",
             "vectorcode.exclude": "*/tests/*",
         }


### PR DESCRIPTION
The `init` subcommand didn't copy the global `config.json5`. This PR fixes the issue.