### PR TITLE
Drop support for nvim-lspconfig and only use `vim.lsp.config`.

### DIFF
--- a/doc/VectorCode.txt
+++ b/doc/VectorCode.txt
@@ -354,11 +354,9 @@ used in previous versions;
 2. The `lsp` based backend, which make use of the experimental `vectorcode-server`
 implemented in version 0.4.0. If you want to customise the LSP executable or
 any options supported by `vim.lsp.ClientConfig`, you can do so by using
-`vim.lsp.config()` or
-nvim-lspconfig <https://github.com/neovim/nvim-lspconfig>. The LSP will
-attempt to read configurations from these 2 sources before it starts. (If
-`vim.lsp.config.vectorcode_server` is not `nil`, this will be used and
-nvim-lspconfig will be ignored.)
+`vim.lsp.config()`. This plugin will load the config associated with the name
+`vectorcode_server`. You can override the default config (for example, the
+path to the executable) by calling `vim.lsp.config('vectorcode_server', opts)`.
 
   -------------------------------------------------------------------------------
   Features   default                         lsp

--- a/doc/VectorCode.txt
+++ b/doc/VectorCode.txt
@@ -54,7 +54,7 @@ Use your favorite plugin manager.
 >lua
     {
       "Davidyz/VectorCode",
-      version = "<0.7.0", -- optional, depending on whether you're on nightly or release
+      version = "*", -- optional, depending on whether you're on nightly or release
       dependencies = { "nvim-lua/plenary.nvim" },
       cmd = "VectorCode", -- if you're lazy-loading VectorCode
     }

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -320,11 +320,9 @@ interface:
 2. The `lsp` based backend, which make use of the experimental `vectorcode-server`
    implemented in version 0.4.0. If you want to customise the LSP executable or
    any options supported by `vim.lsp.ClientConfig`, you can do so by using
-   `vim.lsp.config()` or 
-   [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). The LSP will
-   attempt to read configurations from these 2 sources before it starts. (If
-   `vim.lsp.config.vectorcode_server` is not `nil`, this will be used and
-   nvim-lspconfig will be ignored.)
+   `vim.lsp.config()`. This plugin will load the config associated with the name
+   `vectorcode_server`. You can override the default config (for example, the
+   path to the executable) by calling `vim.lsp.config('vectorcode_server', opts)`.
 
 
 | Features | `default`                                                                                                 | `lsp`                                                                                                                     |

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -43,7 +43,7 @@ Use your favorite plugin manager.
 ```lua 
 {
   "Davidyz/VectorCode",
-  version = "<0.7.0", -- optional, depending on whether you're on nightly or release
+  version = "*", -- optional, depending on whether you're on nightly or release
   dependencies = { "nvim-lua/plenary.nvim" },
   cmd = "VectorCode", -- if you're lazy-loading VectorCode
 }

--- a/lua/vectorcode/config.lua
+++ b/lua/vectorcode/config.lua
@@ -49,13 +49,6 @@ local lsp_configs = function()
     -- nvim >= 0.11.0
     cfg = vim.tbl_deep_extend("force", cfg, vim.lsp.config.vectorcode_server)
     logger.debug("Using vim.lsp.config.vectorcode_server for LSP config:\n", cfg)
-  else
-    -- nvim < 0.11.0
-    local ok, lspconfig = pcall(require, "lspconfig.configs")
-    if ok and lspconfig.vectorcode_server ~= nil then
-      cfg = lspconfig.vectorcode_server.config_def.default_config
-      logger.debug("Using nvim-lspconfig for LSP config:\n", cfg)
-    end
   end
   cfg.name = "vectorcode_server"
   if setup_config.sync_log_env_var then


### PR DESCRIPTION
Since nvim-lspconfig has migrated to use `lsp/`, we can safely drop the old syntax for configuring the LSP.