### PR TITLE
Pin posthog to `<6.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "colorlog",
     "charset-normalizer>=3.4.1",
     "json5",
+    "posthog<6.0.0",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"


### PR DESCRIPTION
See https://github.com/chroma-core/chroma/issues/4966

Since we're still using chromadb `0.6.3`, we'd have to do it ourselves.