### PR TITLE
Add heirline component

### DIFF
--- a/doc/VectorCode.txt
+++ b/doc/VectorCode.txt
@@ -109,7 +109,8 @@ contains instructions to integrate VectorCode with the following plugins:
 - olimorris/codecompanion.nvim <https://github.com/olimorris/codecompanion.nvim>;
 - nvim-lualine/lualine.nvim <https://github.com/nvim-lualine/lualine.nvim>;
 - CopilotC-Nvim/CopilotChat.nvim <https://github.com/CopilotC-Nvim/CopilotChat.nvim>;
-- ravitemer/mcphub.nvim <https://github.com/ravitemer/mcphub.nvim>.
+- ravitemer/mcphub.nvim <https://github.com/ravitemer/mcphub.nvim>;
+- rebelot/heirline.nvim <https://github.com/rebelot/heirline.nvim>.
 
 
 CONFIGURATION                         *VectorCode-neovim-plugin-configuration*

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -94,7 +94,8 @@ contains instructions to integrate VectorCode with the following plugins:
 - [olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim);
 - [nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim);
 - [CopilotC-Nvim/CopilotChat.nvim](https://github.com/CopilotC-Nvim/CopilotChat.nvim);
-- [ravitemer/mcphub.nvim](https://github.com/ravitemer/mcphub.nvim).
+- [ravitemer/mcphub.nvim](https://github.com/ravitemer/mcphub.nvim);
+- [rebelot/heirline.nvim](https://github.com/rebelot/heirline.nvim).
 
 ## Configuration
 

--- a/lua/vectorcode/integrations/heirline.lua
+++ b/lua/vectorcode/integrations/heirline.lua
@@ -1,0 +1,16 @@
+---@class VectorCode.Heirline.Opts: VectorCode.Lualine.Opts
+local default_opts = { show_job_count = false }
+
+---@param opts VectorCode.Heirline.Opts?
+return function(opts)
+  opts = vim.tbl_deep_extend("force", default_opts, opts or {}) --[[@as VectorCode.Heirline.Opts]]
+  local lualine_comp = require("vectorcode.integrations").lualine(opts)
+  return {
+    provider = function(_)
+      return lualine_comp[1]()
+    end,
+    condition = function(_)
+      return lualine_comp.cond()
+    end,
+  }
+end

--- a/lua/vectorcode/integrations/heirline.lua
+++ b/lua/vectorcode/integrations/heirline.lua
@@ -1,21 +1,22 @@
 ---@class VectorCode.Heirline.Opts: VectorCode.Lualine.Opts
---- Passed directly to the `hl` field of the component.
----@field hl table|string|nil
+--- Other heirline component fields (like `hl`, `on_click`, `update`, etc.)
+---@field component_opts table
 
 ---@type VectorCode.Heirline.Opts
-local default_opts = { show_job_count = false }
+local default_opts = { show_job_count = false, component_opts = {} }
 
 ---@param opts VectorCode.Heirline.Opts?
 return function(opts)
   opts = vim.tbl_deep_extend("force", default_opts, opts or {}) --[[@as VectorCode.Heirline.Opts]]
   local lualine_comp = require("vectorcode.integrations").lualine(opts)
-  return {
+  local heirline_component = {
     provider = function(_)
       return lualine_comp[1]()
     end,
     condition = function(_)
       return lualine_comp.cond()
     end,
-    hl = opts.hl,
   }
+
+  return vim.tbl_deep_extend("force", heirline_component, opts.component_opts)
 end

--- a/lua/vectorcode/integrations/heirline.lua
+++ b/lua/vectorcode/integrations/heirline.lua
@@ -1,4 +1,8 @@
 ---@class VectorCode.Heirline.Opts: VectorCode.Lualine.Opts
+--- Passed directly to the `hl` field of the component.
+---@field hl table|string|nil
+
+---@type VectorCode.Heirline.Opts
 local default_opts = { show_job_count = false }
 
 ---@param opts VectorCode.Heirline.Opts?
@@ -12,5 +16,6 @@ return function(opts)
     condition = function(_)
       return lualine_comp.cond()
     end,
+    hl = opts.hl,
   }
 end

--- a/lua/vectorcode/integrations/init.lua
+++ b/lua/vectorcode/integrations/init.lua
@@ -2,4 +2,5 @@ return {
   codecompanion = require("vectorcode.integrations.codecompanion"),
   copilotchat = require("vectorcode.integrations.copilotchat"),
   lualine = require("vectorcode.integrations.lualine"),
+  heirline = require("vectorcode.integrations.heirline"),
 }

--- a/lua/vectorcode/integrations/lualine.lua
+++ b/lua/vectorcode/integrations/lualine.lua
@@ -1,6 +1,7 @@
 local vc_config = require("vectorcode.config")
 
 ---@class VectorCode.Lualine.Opts
+---Whether to show the number of running async jobs.
 ---@field show_job_count boolean
 
 ---@param opts VectorCode.Lualine.Opts?

--- a/lua/vectorcode/integrations/lualine.lua
+++ b/lua/vectorcode/integrations/lualine.lua
@@ -1,8 +1,11 @@
 local vc_config = require("vectorcode.config")
 
----@param opts {show_job_count: boolean}?
+---@class VectorCode.Lualine.Opts
+---@field show_job_count boolean
+
+---@param opts VectorCode.Lualine.Opts?
 return function(opts)
-  opts = vim.tbl_deep_extend("force", { show_job_count = false }, opts or {})
+  opts = vim.tbl_deep_extend("force", { show_job_count = false }, opts or {}) --[[@as VectorCode.Lualine.Opts]]
   local cacher = vc_config.get_cacher_backend()
   return {
     function()


### PR DESCRIPTION
Closes #225 .

The heirline component is accessible via the following snippet:
```lua
require("vectorcode.integrations").heirline({ 
  show_job_count = true,
  component_opts = {
    -- put other field of the components here.
    -- they'll be merged into the final component.
  },
})
```