### PR TITLE
fix(nvim): starting lsp requires an attached buffer

### DIFF
--- a/lua/vectorcode/jobrunner/lsp.lua
+++ b/lua/vectorcode/jobrunner/lsp.lua
@@ -19,6 +19,9 @@ function jobrunner.init(ok_to_fail)
     return CLIENT.id
   end
   ok_to_fail = ok_to_fail or true
+  if not vim.api.nvim_buf_is_loaded(0) then
+    vim.cmd("edit")
+  end
   local client_id = vim.lsp.start(vc_config.lsp_configs(), {})
   if client_id ~= nil then
     -- server started


### PR DESCRIPTION
Constantly getting the following error when starting vectorcode-server on setup due to starting an lsp without an attached buffer. This also causes neovim to send `shutdown` and `exit` requests to the lsp server, and as a side effect, sending back a client id of nil.

`Failed to start vectorcode-server due some error`

Raising a PR to create a temp buffer during setup phase so that `vim.lsp.start` correctly proceeds and returns with status 0.