### PR TITLE
Update tool descriptions for better loading time

### DIFF
--- a/lua/vectorcode/integrations/codecompanion/ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/ls_tool.lua
@@ -1,7 +1,6 @@
 ---@module "codecompanion"
 
 local cc_common = require("vectorcode.integrations.codecompanion.common")
-local vectorcode = require("vectorcode")
 local vc_config = require("vectorcode.config")
 local logger = vc_config.logger
 
@@ -60,10 +59,10 @@ return function(opts)
       type = "function",
       ["function"] = {
         name = tool_name,
-        description = string.format(
-          "Retrieve a list of projects accessible via the VectorCode tools.\n%s",
-          table.concat(vectorcode.prompts("ls"), "\n")
-        ),
+        description = [[
+Retrieve a list of projects accessible via the VectorCode tools.
+Where relevant, use paths from this tool as the `project_root` parameter in other vectorcode tools.
+]],
       },
     },
     output = {

--- a/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
@@ -1,7 +1,6 @@
 ---@module "codecompanion"
 
 local cc_common = require("vectorcode.integrations.codecompanion.common")
-local vectorcode = require("vectorcode")
 local vc_config = require("vectorcode.config")
 local logger = vc_config.logger
 
@@ -43,10 +42,10 @@ return function(opts)
       type = "function",
       ["function"] = {
         name = tool_name,
-        description = string.format(
-          "Vectorise files in a project so that they'll be available from the vectorcode_query tool\n%s",
-          table.concat(vectorcode.prompts("vectorise"), "\n")
-        ),
+        description = [[
+Vectorise files in a project so that they'll be available from the `vectorcode_query` tool.
+The paths should be accurate (DO NOT ASSUME A PATH EXIST) and case case-sensitive.
+]],
         parameters = {
           type = "object",
           properties = {


### PR DESCRIPTION
This PR refactors the codecompanion tools to use hardcoded schema descriptions so that they don't call the `vectorcode prompts` command.

Closes #243 .

@musaffa, please give this a try and lmk if it make the loading faster.