### PR TITLE
Allow `py-tree-sitter>0.25.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "numpy",
     "psutil",
     "httpx",
-    "tree-sitter<0.25.0",
+    "tree-sitter!=0.25.0",
     "tree-sitter-language-pack",
     "pygments",
     "transformers>=4.36.0,!=4.51.0,!=4.51.1,!=4.51.2",


### PR DESCRIPTION
[The upstream build issue on aarch64 linux](https://github.com/tree-sitter/py-tree-sitter/pull/393) has been resolved.