### PR TITLE
Add VectorCode prompt library integration for Neovim help files

### DIFF
--- a/lua/codecompanion/_extensions/vectorcode/init.lua
+++ b/lua/codecompanion/_extensions/vectorcode/init.lua
@@ -52,7 +52,8 @@ local M = {
     opts.tool_opts = merge_tool_opts(opts.tool_opts)
     logger.info("Received codecompanion extension opts:\n", opts)
     local cc_config = require("codecompanion.config").config
-    local cc_integration = require("vectorcode.integrations").codecompanion.chat
+    local cc_integration = require("vectorcode.integrations").codecompanion
+    local cc_chat_integration = cc_integration.chat
     for _, sub_cmd in pairs(valid_tools) do
       local tool_name = string.format("vectorcode_%s", sub_cmd)
       if cc_config.strategies.chat.tools[tool_name] ~= nil then
@@ -73,7 +74,7 @@ local M = {
       else
         cc_config.strategies.chat.tools[tool_name] = {
           description = string.format("Run VectorCode %s tool", sub_cmd),
-          callback = cc_integration.make_tool(sub_cmd, opts.tool_opts[sub_cmd]),
+          callback = cc_chat_integration.make_tool(sub_cmd, opts.tool_opts[sub_cmd]),
           opts = { requires_approval = opts.tool_opts[sub_cmd].requires_approval },
         }
         logger.info(string.format("%s tool has been created.", tool_name))
@@ -104,6 +105,14 @@ local M = {
         description = "Use VectorCode to automatically build and retrieve repository-level context.",
         tools = included_tools,
       }
+    end
+
+    for _, prompt in pairs(cc_integration.prompts) do
+      if type(prompt) == "function" then
+        ---@diagnostic disable-next-line: cast-local-type
+        prompt = prompt()
+      end
+      cc_config.prompt_library[prompt.name] = prompt.prompts
     end
   end),
 }

--- a/lua/vectorcode/integrations/codecompanion/init.lua
+++ b/lua/vectorcode/integrations/codecompanion/init.lua
@@ -56,4 +56,7 @@ return {
       end
     end,
   },
+  prompts = {
+    require("vectorcode.integrations.codecompanion.prompts.nvim"),
+  },
 }

--- a/lua/vectorcode/integrations/codecompanion/prompts/nvim.lua
+++ b/lua/vectorcode/integrations/codecompanion/prompts/nvim.lua
@@ -1,0 +1,58 @@
+---@module "codecompanion"
+
+return require("vectorcode.config").check_cli_wrap(function()
+  local constants = require("codecompanion.config").config.constants
+  local rtp = vim.fs.normalize(vim.env.VIMRUNTIME)
+
+  if not rtp then
+    return error("Failed to locate the neovim runtime!", vim.log.levels.ERROR)
+  end
+  local stat = vim.uv.fs_stat(rtp)
+  if not stat or stat.type ~= "directory" then
+    return error(
+      string.format(
+        "$VIMRUNTIME is %s, which is not a valid directory to be accessed.",
+        rtp
+      ),
+      vim.log.levels.ERROR
+    )
+  end
+  return {
+    name = "Neovim Assistant",
+    prompts = {
+      strategy = "chat",
+      description = "Use VectorCode to index and query from neovim documentation and lua runtime.",
+
+      prompts = {
+        {
+          role = constants.SYSTEM_ROLE,
+          content = string.format(
+            [[You are an neovim expert.
+You will be given tools to index and query from the neovim runtime library.
+This will include lua APIs for the neovim runtime and documentation for the neovim build that the user is running.
+Use the tools to explain the user's questions related to neovim.
+The runtime files are stored in `%s`.
+You can ONLY use the vectorcode tools to interact with these files or directory.
+DO NOT attempt to read from or write into this directory.
+]],
+            rtp
+          ),
+        },
+        {
+          role = constants.USER_ROLE,
+          content = string.format(
+            [[
+You are given the @{vectorcode_vectorise} and @{vectorcode_query} tools.
+Vectorrise all lua files and `*.txt` files under this directory using the `vectorcode_vectorise` tool. Use wildcards to match all lua and `txt` files. Use absolute paths when supplying paths to the vectorcode_vectorise tool;
+Use `%s` as the value of the `project_root` argument;
+When you're done, I'll be asking you questions related to these documents.
+Use the vectorcode_query tool to query from the project root and answer my question.
+]],
+            rtp,
+            rtp
+          ),
+        },
+      },
+    },
+  }
+end)


### PR DESCRIPTION
This PR provides a streamlined experience of indexing and querying the neovim runtime (including the lua source code/type stub and the help doc).