### PR TITLE
Allow truncating embeddings to specified dimensions.

### DIFF
--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -89,6 +89,7 @@ class Config:
     db_url: str = "http://127.0.0.1:8000"
     embedding_function: str = "SentenceTransformerEmbeddingFunction"  # This should fallback to whatever the default is.
     embedding_params: dict[str, Any] = field(default_factory=(lambda: {}))
+    embedding_dims: Optional[int] = None
     n_result: int = 1
     force: bool = False
     db_path: Optional[str] = "~/.local/share/vectorcode/chromadb/"
@@ -138,6 +139,9 @@ class Config:
                 ),
                 "embedding_params": config_dict.get(
                     "embedding_params", default_config.embedding_params
+                ),
+                "embedding_dims": config_dict.get(
+                    "embedding_dims", default_config.embedding_dims
                 ),
                 "db_url": config_dict.get("db_url", default_config.db_url),
                 "db_path": db_path,

--- a/src/vectorcode/subcommands/vectorise.py
+++ b/src/vectorcode/subcommands/vectorise.py
@@ -146,12 +146,21 @@ async def chunked_add(
             async with collection_lock:
                 for idx in range(0, len(chunks), max_batch_size):
                     inserted_chunks = chunks[idx : idx + max_batch_size]
+                    embeddings = embedding_function(
+                        list(str(c) for c in inserted_chunks)
+                    )
+                    if (
+                        isinstance(configs.embedding_dims, int)
+                        and configs.embedding_dims > 0
+                    ):
+                        logger.debug(
+                            f"Truncating embeddings to {configs.embedding_dims} dimensions."
+                        )
+                        embeddings = [e[: configs.embedding_dims] for e in embeddings]
                     await collection.add(
                         ids=[get_uuid() for _ in inserted_chunks],
                         documents=[str(i) for i in inserted_chunks],
-                        embeddings=embedding_function(
-                            list(str(c) for c in inserted_chunks)
-                        ),
+                        embeddings=embeddings,
                         metadatas=metas,
                     )
     except (UnicodeDecodeError, UnicodeError):  # pragma: nocover


### PR DESCRIPTION
A lot of embedding models support truncating the embedding output to accelerate the query. However, not all chromadb embedding function adapters (Ollama) support this. This PR adds the option for the users to set a customised embedding dimension where appropriate.

Note: If you changed the dimension for an existing collection, you'd need to `drop` it and re-vectorise. Otherwise, the queries won't work because the embedding dimensions must align.