### PR TITLE
Handle relative paths for codecompanion tools

### DIFF
--- a/lua/vectorcode/integrations/codecompanion/common.lua
+++ b/lua/vectorcode/integrations/codecompanion/common.lua
@@ -42,4 +42,13 @@ return {
     end
     return job_runner
   end,
+
+  ---Convert `path` to a relative path if it's within the current project.
+  ---@param path string
+  ---@param base? string
+  ---@return string
+  cleanup_path = function(path, base)
+    base = base or vim.fs.root(0, { ".vectorcode", ".git" }) or vim.uv.cwd() or "."
+    return vim.fs.relpath(base, path) or path
+  end,
 }

--- a/lua/vectorcode/integrations/codecompanion/common.lua
+++ b/lua/vectorcode/integrations/codecompanion/common.lua
@@ -44,6 +44,8 @@ return {
   end,
 
   ---Convert `path` to a relative path if it's within the current project.
+  ---When `base` is `nil`, this function will attempt to find a project root
+  ---or use `cwd`.
   ---@param path string
   ---@param base? string
   ---@return string

--- a/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
@@ -57,7 +57,11 @@ return function(opts)
       type = "function",
       ["function"] = {
         name = tool_name,
-        description = "Retrieve a list of files that have been added to the database for a given project.",
+        description = [[
+Retrieve a list of files that have been added to the database for a given project.
+**ABSOLUTE PATHS** in the results indicate that the files are OUTSIDE of the current working directories and you can **ONLY** access them via the VectorCode tools.
+**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them.
+          ]],
         parameters = {
           type = "object",
           properties = {
@@ -73,7 +77,7 @@ return function(opts)
       ---@param tools CodeCompanion.Tools
       ---@param stdout string[][]
       success = function(_, tools, _, stdout)
-        stdout = stdout[1]
+        stdout = stdout[#stdout]
         local user_message
         for i, col in ipairs(stdout) do
           if i == 1 then
@@ -84,7 +88,7 @@ return function(opts)
           end
           tools.chat:add_tool_output(
             tools.tool,
-            string.format("<path>%s</path>", col),
+            string.format("<path>%s</path>", cc_common.cleanup_path(col)),
             user_message
           )
         end

--- a/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
@@ -60,7 +60,7 @@ return function(opts)
         description = [[
 Retrieve a list of files that have been added to the database for a given project.
 **ABSOLUTE PATHS** in the results indicate that the files are OUTSIDE of the current working directories and you can **ONLY** access them via the VectorCode tools.
-**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them.
+**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them. They are relative to the project root.
           ]],
         parameters = {
           type = "object",

--- a/lua/vectorcode/integrations/codecompanion/ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/ls_tool.lua
@@ -76,7 +76,7 @@ Where relevant, use paths from this tool as the `project_root` parameter in othe
       ---@param tools CodeCompanion.Tools
       ---@param stdout VectorCode.LsResult[][]
       success = function(_, tools, _, stdout)
-        stdout = stdout[1]
+        stdout = stdout[#stdout]
         local user_message
         for i, col in ipairs(stdout) do
           if i == 1 then

--- a/lua/vectorcode/integrations/codecompanion/query_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/query_tool.lua
@@ -325,8 +325,7 @@ local function cleanup_paths(results)
       :map(
         ---@param res VectorCode.QueryResult
         function(res)
-          local orig_path = res.path
-          res.path = vim.fs.relpath(cwd, orig_path) or orig_path
+          res.path = cc_common.cleanup_path(res.path)
           return res
         end
       )

--- a/lua/vectorcode/integrations/codecompanion/query_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/query_tool.lua
@@ -499,7 +499,7 @@ Include one single command call for VectorCode each time.
 You may include multiple keywords in the command.
 **The project root option MUST be a valid path on the filesystem. It can only be one of the results from the `vectorcode_ls` tool or from user input**
 **ABSOLUTE PATHS** in the results indicate that the files are OUTSIDE of the current working directories and you can **ONLY** access them via the VectorCode tools.
-**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them.
+**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them. They are relative to the project root.
         ]],
         parameters = {
           type = "object",

--- a/lua/vectorcode/integrations/codecompanion/query_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/query_tool.lua
@@ -315,6 +315,26 @@ When summarising the code, pay extra attention on information related to the que
   end
 end
 
+---@param results VectorCode.QueryResult[]
+---@return VectorCode.QueryResult[]
+local function cleanup_paths(results)
+  local cwd = vim.fs.root(0, { ".vectorcode", ".git" }) or vim.uv.cwd()
+  if cwd then
+    results = vim
+      .iter(results)
+      :map(
+        ---@param res VectorCode.QueryResult
+        function(res)
+          local orig_path = res.path
+          res.path = vim.fs.relpath(cwd, orig_path) or orig_path
+          return res
+        end
+      )
+      :totable()
+  end
+  return results
+end
+
 ---@param opts VectorCode.CodeCompanion.QueryToolOpts?
 ---@return CodeCompanion.Tools.Tool
 return check_cli_wrap(function(opts)
@@ -436,6 +456,8 @@ return check_cli_wrap(function(opts)
               result = filter_results(result, tools.chat)
             end
 
+            result = cleanup_paths(result)
+
             local max_result = #result
             if opts.max_num > 0 then
               max_result = math.min(tonumber(opts.max_num) or 1, max_result)
@@ -477,6 +499,8 @@ Make use of the line numbers (NOT THE XML TAGS) when you're quoting the source c
 Include one single command call for VectorCode each time.
 You may include multiple keywords in the command.
 **The project root option MUST be a valid path on the filesystem. It can only be one of the results from the `vectorcode_ls` tool or from user input**
+**ABSOLUTE PATHS** in the results indicate that the files are OUTSIDE of the current working directories and you can **ONLY** access them via the VectorCode tools.
+**RELATIVE PATHS** in the results indicate that the files are INSIDE the current project. You can use VectorCode tools or any other tools that the user provided to interact with them.
         ]],
         parameters = {
           type = "object",
@@ -572,7 +596,7 @@ DO NOT MODIFY UNLESS INSTRUCTED BY THE USER, OR A PREVIOUS QUERY RETURNED NO RES
       ---@param cmd QueryToolArgs
       ---@param stdout VectorCode.CodeCompanion.QueryToolResult[]
       success = function(self, tools, cmd, stdout)
-        stdout = stdout[1]
+        stdout = stdout[#stdout]
         logger.info(
           ("CodeCompanion tool with command %s finished."):format(vim.inspect(cmd))
         )

--- a/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
@@ -147,7 +147,7 @@ The paths should be accurate (DO NOT ASSUME A PATH EXIST) and case case-sensitiv
       ---@param cmd VectoriseToolArgs
       ---@param stdout VectorCode.VectoriseResult[]
       success = function(self, tools, cmd, stdout)
-        stdout = stdout[1]
+        stdout = stdout[#stdout]
         tools.chat:add_tool_output(
           self,
           string.format(


### PR DESCRIPTION
Closes #260 

Since other tools in codecompanion.nvim are designed to avoid IO on files outside of `cwd`, this PR differentiate paths inside of `cwd` and outside of `cwd` by using relative paths for the former, and absolute paths for the later. Instructions are included in the `query` and `files_ls` tool schemas so that the model knows that they can't use the other tools on files represented by absolute paths.

Until the upstream rule of "no IO outside of `cwd`" is changed, this extension will stick to this rule when formatting the output.