### PR TITLE
Support using LSP workspace folder as default project root for the LSP server.

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -1,7 +1,6 @@
 name: panvimdoc
 
 on: 
-  push:
   pull_request:
 
 permissions:

--- a/doc/VectorCode-cli.txt
+++ b/doc/VectorCode-cli.txt
@@ -808,8 +808,11 @@ Note that:
 1. For easier parsing, `--pipe` is assumed to be enabled in LSP mode;
 2. A `vectorcode.lock` file will be created in your `db_path` directory **if you’re using the bundled chromadb server**. Please do not delete it while a
 vectorcode process is running;
-3. The LSP server supports `vectorise`, `query` and `ls` subcommands. The other
-subcommands may be added in the future.
+3. The LSP server supports `vectorise`, `query`, `ls` and `files` subcommands. The other
+subcommands may be added in the future;
+4. If the `--project_root` parameter is not provided, the LSP server will try to use the
+workspace folders <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders>
+provided by the LSP client as the project root (if available).
 
 
 MCP SERVER ~

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -730,8 +730,11 @@ Note that:
 2. A `vectorcode.lock` file will be created in your `db_path` directory __if
    you're using the bundled chromadb server__. Please do not delete it while a
    vectorcode process is running;
-3. The LSP server supports `vectorise`, `query` and `ls` subcommands. The other
-   subcommands may be added in the future.
+3. The LSP server supports `vectorise`, `query`, `ls` and `files` subcommands. The other
+   subcommands may be added in the future;
+4. If the `--project_root` parameter is not provided, the LSP server will try to use the 
+   [workspace folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
+   provided by the LSP client as the project root (if available).
 
 ### MCP Server
 


### PR DESCRIPTION
This is part of the plan to move the LSP server options to the standard LSP settings (like `vim.lsp.config`). 