### PR TITLE
Relax schema requirements for CodeCompanion tools (closes #273)

### DIFF
--- a/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
@@ -67,7 +67,13 @@ Retrieve a list of files that have been added to the database for a given projec
           properties = {
             project_root = {
               type = "string",
-              description = "The project for which the indexed files will be listed. Leave this empty for the current project.",
+              description = [[
+The project that the files belong to.
+The value should be one of the following:
+- One of the paths from the `vectorcode_ls` tool;
+- User input;
+- `null` (omit this parameter), which means the current project, if found.
+]],
             },
           },
         },

--- a/lua/vectorcode/integrations/codecompanion/files_rm_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_rm_tool.lua
@@ -37,7 +37,13 @@ return function(opts)
             },
             project_root = {
               type = "string",
-              description = "The project that the files belong to. Either use a path from the `vectorcode_ls` tool, or omit this parameter to use the current git project. If the user did not specify a path, omit this parameter.",
+              description = [[
+The project that the files belong to.
+The value should be one of the following:
+- One of the paths from the `vectorcode_ls` tool;
+- User input;
+- `null` (omit this parameter), which means the current project, if found.
+                ]],
             },
           },
           required = { "paths" },

--- a/lua/vectorcode/integrations/codecompanion/query_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/query_tool.lua
@@ -520,14 +520,20 @@ If a query returned empty or repeated results, you should avoid using these quer
             count = {
               type = "integer",
               description = string.format(
-                "Number of documents or chunks to retrieve, must be positive. Use %d by default. Do not query for more than %d.",
+                "Number of documents or chunks to retrieve, must be positive. The default value of this parameter is %d. Do not query for more than %d results.",
                 tonumber(opts.default_num),
                 tonumber(opts.max_num)
               ),
             },
             project_root = {
               type = "string",
-              description = "Project path to search within (must be from 'ls' results or user instructions). If the user did not specify a project, you may omit this parameter and the tool will try to query from the current project. If this fails, use the `vectorcode_ls` tool and ask the user to clarify the project.",
+              description = [[
+The project that the files belong to.
+The value should be one of the following:
+- One of the paths from the `vectorcode_ls` tool;
+- User input;
+- `null` (omit this parameter), which means the current project, if found.
+                ]],
             },
             allow_summary = {
               type = "boolean",
@@ -617,7 +623,11 @@ DO NOT MODIFY UNLESS INSTRUCTED BY THE USER, OR A PREVIOUS QUERY RETURNED NO RES
                 return process_result(res)
               end)
               :totable()),
-          string.format("**VectorCode Tool**: Retrieved %d %s(s)", stdout.count, mode)
+          string.format(
+            "**VectorCode `query` Tool**: Retrieved %d %s(s)",
+            stdout.count,
+            mode
+          )
         )
         if not opts.chunk_mode then
           for _, result in pairs(stdout.raw_results) do

--- a/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
@@ -56,7 +56,13 @@ The paths should be accurate (DO NOT ASSUME A PATH EXIST) and case case-sensitiv
             },
             project_root = {
               type = "string",
-              description = "The project that the files belong to. Either use a path from the `vectorcode_ls` tool, or leave empty to use the current git project. If the user did not specify a path, you may omit this parameter.",
+              description = [[
+The project that the files belong to.
+The value should be one of the following:
+- One of the paths from the `vectorcode_ls` tool;
+- User input;
+- `null` (omit this parameter), which means the current project, if found.
+]],
             },
           },
           required = { "paths" },
@@ -126,7 +132,7 @@ The paths should be accurate (DO NOT ASSUME A PATH EXIST) and case case-sensitiv
         stderr = cc_common.flatten_table_to_string(stderr)
         tools.chat:add_tool_output(
           self,
-          string.format("**VectorCode Vectorise Tool: %s", stderr)
+          string.format("**VectorCode `vectorise` Tool: %s", stderr)
         )
       end,
       ---@param self CodeCompanion.Tools.Tool
@@ -138,7 +144,7 @@ The paths should be accurate (DO NOT ASSUME A PATH EXIST) and case case-sensitiv
         tools.chat:add_tool_output(
           self,
           string.format(
-            [[**VectorCode Vectorise Tool**:
+            [[**VectorCode `vectorise` Tool**:
   - New files added: %d
   - Existing files updated: %d
   - Orphaned files removed: %d


### PR DESCRIPTION
This PR refactors the codecompanion.nvim tool schemas so that they don't mark all arguments as `required`. This should make the parameters more comprehensive for the LLMs to understand, and avoid confusions when they want to just use the default values.

Relevant discussion: #272 