### PR TITLE
fix(nvim): convert `vim.NIL` args to `nil` in codecompanion tools

### DIFF
--- a/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_ls_tool.lua
@@ -28,6 +28,7 @@ return function(opts)
       ---@return nil|{ status: string, data: string }
       function(tools, action, _, cb)
         local args = { "files", "ls", "--pipe" }
+        action = utils.fix_nil(action)
         if action ~= nil then
           action.project_root = action.project_root
             or vim.fs.root(0, { ".vectorcode", ".git" })

--- a/lua/vectorcode/integrations/codecompanion/files_rm_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/files_rm_tool.lua
@@ -58,6 +58,7 @@ The value should be one of the following:
       ---@return nil|{ status: string, data: string }
       function(tools, action, _, cb)
         local args = { "files", "rm", "--pipe" }
+        action = utils.fix_nil(action)
         if action.project_root then
           local project_root = vim.fs.abspath(vim.fs.normalize(action.project_root))
           if utils.is_directory(project_root) then
@@ -85,7 +86,7 @@ The value should be one of the following:
           args,
           ---@param result VectoriseResult
           function(result, error, code, _)
-            if result then
+            if code == 0 then
               cb({ status = "success", data = result })
             else
               cb({ status = "error", data = { error = error, code = code } })

--- a/lua/vectorcode/integrations/codecompanion/query_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/query_tool.lua
@@ -385,7 +385,7 @@ return check_cli_wrap(function(opts)
           "CodeCompanion query tool called with the following arguments:\n",
           action
         )
-
+        action = utils.fix_nil(action)
         if action.deduplicate == nil then
           action.deduplicate = opts.no_duplicate
         end

--- a/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
+++ b/lua/vectorcode/integrations/codecompanion/vectorise_tool.lua
@@ -76,6 +76,7 @@ The value should be one of the following:
       ---@return nil|{ status: string, data: string }
       function(tools, action, _, cb)
         local args = { "vectorise", "--pipe" }
+        action = utils.fix_nil(action)
         if action.project_root then
           local project_root = vim.fs.abspath(vim.fs.normalize(action.project_root))
           if utils.is_directory(project_root) then

--- a/lua/vectorcode/utils.lua
+++ b/lua/vectorcode/utils.lua
@@ -201,4 +201,20 @@ M.flatten_table_to_string = function(t, fallback)
   return table.concat(flattened, "\n")
 end
 
+---Convert any `vim.NIL` instances to `nil` in lua.
+---@generic Obj: any
+---@param obj Obj
+---@return Obj
+function M.fix_nil(obj)
+  if obj == vim.NIL then
+    return nil
+  end
+  if type(obj) == "table" then
+    for k, v in pairs(obj) do
+      obj[k] = M.fix_nil(v)
+    end
+  end
+  return obj
+end
+
 return M


### PR DESCRIPTION
Some LLMs decide to send `null`s in tool args, which then get converted to `vim.NIL`.