### PR TITLE
Neovim LSP integration: Detach buffers only when attached

### DIFF
--- a/lua/vectorcode/cacher/lsp.lua
+++ b/lua/vectorcode/cacher/lsp.lua
@@ -227,7 +227,7 @@ M.register_buffer = vc_config.check_cli_wrap(
       desc = "Kill all running VectorCode async jobs.",
       group = group,
       callback = function()
-        if client_id ~= nil then
+        if client_id ~= nil and vim.lsp.buf_is_attached(bufnr, client_id) then
           vim.lsp.buf_detach_client(bufnr, client_id)
         end
       end,
@@ -255,7 +255,7 @@ M.deregister_buffer = vc_config.check_cli_wrap(
       kill_jobs(bufnr)
       vim.api.nvim_del_augroup_by_name(("VectorCodeCacheGroup%d"):format(bufnr))
       CACHE[bufnr] = nil
-      if client_id ~= nil then
+      if client_id ~= nil and vim.lsp.buf_is_attached(bufnr, client_id) then
         vim.lsp.buf_detach_client(bufnr, client_id)
       end
       if opts.notify then


### PR DESCRIPTION
When switching to files that are not yet buffered I get the following error:

```
Buffer (id: [X]) is not attached to client (id: [Y]). Cannot detach.
"/path/to/file" 15L, 351B
```

This appears to be as a result of a race condition when detaching buffers - something in my config is potentially detaching buffers and then vectorcode attempts to do the same after they are already detached.

I tried to create a minimal neovim repro, but with the extent of my config it'd be a nightmare to minimise, so I've provided a screencast instead:

[Recording at 2025-12-16 22.53.40 (Cropped in 2025-12-16 22.54.37)_compressed.webm](https://github.com/user-attachments/assets/662223f3-1bb7-4832-8482-86d546e45fbb)

## Reproduction Steps

- add a decade's worth of vim configs to neovim
- configure vectorcode lsp integration in neovim
- open an unbuffered file
- open a new unbuffered file in the same buffer

Expect: no error
Actual: error raised

## Neovim Vectorcode Config

```lua
return {
	"Davidyz/VectorCode",
	version = "*",
	build = "uv tool upgrade vectorcode",
	dependencies = { "nvim-lua/plenary.nvim" },
	cond = function()
		return vim.fn.executable("vectorcode") == 1
	end,
	event = { "BufReadPost", "BufNewFile" },
	config = function()
		require("vectorcode").setup(
			---@type VectorCode.Opts
			{
				cli_cmds = {
					vectorcode = "vectorcode",
				},
				-- options used when attaching to LSP, below
				---@type VectorCode.RegisterOpts
				async_opts = {
					debounce = 100, -- Debounce time in milliseconds to avoid excessive updates
					events = { "BufWritePost", "InsertLeave", "BufReadPost" }, -- Events that trigger automatic file indexing
					exclude_this = true, -- Exclude current buffer from automatic indexing
					n_query = 1, -- Number of queries to send for each indexing operation
					notify = true, -- Show notifications when indexing operations occur
					query_cb = require("vectorcode.utils").make_surrounding_lines_cb(-1), -- Use surrounding lines as context for better indexing
					-- Don't automatically index when files are manually registered
					-- Use `:VectorCode register` to register specific files for indexing
					run_on_register = false,
				},
				async_backend = "lsp", -- Backend to use for async operations (default or lsp)
				exclude_this = true, -- Exclude current buffer from operations
				n_query = 10, -- Number of queries to send for each operation
				notify = true, -- Show notifications for operations
				timeout_ms = 5000, -- Timeout in milliseconds for operations
				on_setup = {
					update = true, -- Update VectorCode on setup
					lsp = false, -- Disable automatic LSP startup during setup
				},
				sync_log_env_var = false, -- Don't sync environment variables for logging
			}
		)

		vim.api.nvim_create_autocmd("LspAttach", {
			callback = function()
				local cacher = require("vectorcode.cacher")
				local bufnr = vim.api.nvim_get_current_buf()

				cacher.utils.async_check("config", function()
					cacher.lsp.register_buffer(bufnr, {
						-- provide rich context for LSP queries
						n_query = 10,
					})
				end, nil)
			end,
			desc = "Register buffer for VectorCode",
		})
	end,
}
```

## Solution

Before calling `vim.lsp.buf_detach_client`, check that the buffer is attached using `vim.lsp.buf_is_attached`