### PR TITLE
Fix UnicodeDecodeError on Windows by standardizing to UTF-8 encoding

### DIFF
--- a/src/vectorcode/cli_utils.py
+++ b/src/vectorcode/cli_utils.py
@@ -492,7 +492,7 @@ async def load_config_file(path: Optional[Union[str, Path]] = None):
                 break
     if path and os.path.isfile(path):
         logger.debug(f"Loading config from {path}")
-        with open(path) as fin:
+        with open(path, encoding="utf-8") as fin:
             content = fin.read()
         if content:
             config = json5.loads(content)
@@ -681,7 +681,7 @@ class LockManager:
             lock_file = os.path.join(path, "vectorcode.lock")
             logger.info(f"Creating {lock_file} for locking.")
             if not os.path.isfile(lock_file):
-                with open(lock_file, mode="w") as fin:
+                with open(lock_file, mode="w", encoding="utf-8") as fin:
                     fin.write("")
             path = lock_file
         if self.__locks.get(path) is None:
@@ -719,7 +719,7 @@ class SpecResolver:
 
     def __init__(self, spec: str | GitIgnoreSpec, base_dir: str = "."):
         if isinstance(spec, str):
-            with open(spec) as fin:
+            with open(spec, encoding="utf-8") as fin:
                 self.spec = GitIgnoreSpec.from_lines(
                     (i.strip() for i in fin.readlines())
                 )

--- a/src/vectorcode/mcp_main.py
+++ b/src/vectorcode/mcp_main.py
@@ -218,7 +218,7 @@ async def query_tool(
             for result in result_paths:
                 if isinstance(result, str):
                     if os.path.isfile(result):
-                        with open(result) as fin:
+                        with open(result, encoding="utf-8") as fin:
                             rel_path = os.path.relpath(result, config.project_root)
                             results.append(
                                 f"<path>{rel_path}</path>\n<content>{fin.read()}</content>",

--- a/src/vectorcode/subcommands/init.py
+++ b/src/vectorcode/subcommands/init.py
@@ -49,7 +49,7 @@ def load_hooks():
     global __HOOK_CONTENTS
     for file in glob.glob(str(__GLOBAL_HOOKS_PATH / "*")):
         hook_name = Path(file).stem
-        with open(file) as fin:
+        with open(file, encoding="utf-8") as fin:
             lines = fin.readlines()
             if not __lines_are_empty(lines):
                 __HOOK_CONTENTS[hook_name] = lines
@@ -65,7 +65,7 @@ class HookFile:
         self.path = path
         self.lines: list[str] = []
         if os.path.isfile(self.path):
-            with open(self.path) as fin:
+            with open(self.path, encoding="utf-8") as fin:
                 self.lines.extend(fin.readlines())
 
     def has_vectorcode_hooks(self, force: bool = False) -> bool:
@@ -92,7 +92,7 @@ class HookFile:
             self.lines.append(self.prefix + "\n")
             self.lines.extend(i if i.endswith("\n") else i + "\n" for i in content)
             self.lines.append(self.suffix + "\n")
-        with open(self.path, "w") as fin:
+        with open(self.path, "w", encoding="utf-8") as fin:
             if os.path.islink(self.path):  # pragma: nocover
                 logger.warning(f"{self.path} is a symlink.")
             fin.writelines(self.lines)

--- a/src/vectorcode/subcommands/query/__init__.py
+++ b/src/vectorcode/subcommands/query/__init__.py
@@ -151,7 +151,7 @@ async def build_query_results(
             if not os.path.isfile(io_path):
                 logger.warning(f"{io_path} is no longer a valid file.")
                 continue
-            with open(io_path) as fin:
+            with open(io_path, encoding="utf-8") as fin:
                 structured_result.append({"path": output_path, "document": fin.read()})
         else:
             res = cast(Chunk, res)

--- a/src/vectorcode/subcommands/vectorise.py
+++ b/src/vectorcode/subcommands/vectorise.py
@@ -219,13 +219,13 @@ def load_files_from_include(project_root: str) -> list[str]:
     specs: Optional[pathspec.GitIgnoreSpec] = None
     if os.path.isfile(include_file_path):
         logger.debug("Loading from local `vectorcode.include`.")
-        with open(include_file_path) as fin:
+        with open(include_file_path, encoding="utf-8") as fin:
             specs = pathspec.GitIgnoreSpec.from_lines(
                 lines=(os.path.expanduser(i) for i in fin.readlines()),
             )
     elif os.path.isfile(GLOBAL_INCLUDE_SPEC):
         logger.debug("Loading from global `vectorcode.include`.")
-        with open(GLOBAL_INCLUDE_SPEC) as fin:
+        with open(GLOBAL_INCLUDE_SPEC, encoding="utf-8") as fin:
             specs = pathspec.GitIgnoreSpec.from_lines(
                 lines=(os.path.expanduser(i) for i in fin.readlines()),
             )


### PR DESCRIPTION
This PR standardises Unicode encodings to UTF-8 across the codebase by adding explicit `encoding='utf-8'` to `open()` calls.

### Rationale
On Windows, the default locale encoding (e.g., CP1252 or CP949) often differs from UTF-8. When `vectorcode` attempts to read code files or configuration files containing non-ASCII characters without an explicit encoding, it throws a `UnicodeDecodeError`. 

This has been reported in Issue #307, specifically for the `query` command.

### Changes
- Updated `src/vectorcode/subcommands/query/__init__.py` to use UTF-8 when reading document source during query result building.
- Updated `src/vectorcode/subcommands/vectorise.py` to use UTF-8 for include/exclude specifications.
- Updated `src/vectorcode/subcommands/init.py` for git hook and configuration file operations.
- Updated `src/vectorcode/cli_utils.py` for general configuration loading.
- Updated `src/vectorcode/mcp_main.py` for MCP tool result processing.

These changes ensure that `vectorcode` remains robust and cross-platform compatible when handling modern UTF-8 codebase files.